### PR TITLE
Added new features includding the new union types, testing, and others

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,30 @@
 {
   "name": "sqm",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqm",
-      "version": "0.5.9",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-pattern": "^5.8.0"
       },
       "devDependencies": {
         "@swc/core": "^1.13.5",
+        "@vitest/coverage-v8": "^3.2.4",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "concurrently": "^9.2.1",
+        "nodemon": "^3.1.10",
         "terser": "^5.44.0",
         "tslib": "^2.8.1",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
-        "zod": "^4.1.9"
+        "vitest": "^3.2.4",
+        "wait-on": "^9.0.1",
+        "zod": "^4.1.11"
       },
       "engines": {
         "node": ">=21"
@@ -39,6 +44,80 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -483,6 +562,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.3.tgz",
+      "integrity": "sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -499,6 +632,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -870,6 +1013,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
@@ -1096,6 +1246,23 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1109,6 +1276,155 @@
       "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1156,12 +1472,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz",
+      "integrity": "sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.30",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -1171,6 +1568,19 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer-from": {
@@ -1204,6 +1614,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1241,6 +1738,100 @@
         "validator": "^13.9.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1261,12 +1852,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -1318,6 +1954,41 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1331,6 +2002,62 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -1374,6 +2101,36 @@
         "@esbuild/win32-x64": "0.25.10"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1392,6 +2149,19 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -1402,6 +2172,27 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {
@@ -1421,6 +2212,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1434,6 +2242,65 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1457,6 +2324,121 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1467,12 +2449,102 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -1490,6 +2562,25 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/joi": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.1.tgz",
+      "integrity": "sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -1499,6 +2590,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/libphonenumber-js": {
       "version": "1.12.17",
@@ -1537,10 +2635,24 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1561,6 +2673,67 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -1575,6 +2748,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -1617,6 +2800,162 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nodemon/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/nodemon/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -1670,6 +3009,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1710,6 +3059,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -1755,6 +3133,20 @@
         }
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1777,6 +3169,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -1831,6 +3233,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1854,6 +3279,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1867,10 +3312,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1887,6 +3355,20 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1992,6 +3474,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -2025,6 +3520,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/terser": {
       "version": "5.44.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
@@ -2042,6 +3553,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -2067,6 +3593,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -2089,6 +3622,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/tr46": {
@@ -2219,6 +3805,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/validator": {
       "version": "13.15.15",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
@@ -2227,6 +3820,197 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.6.tgz",
+      "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.1.tgz",
+      "integrity": "sha512-noeCAI+XbqWMXY23sKril0BSURhuLYarkVXwJv1uUWwoojZJE7pmX3vJ7kh7SZaNgPGzfsCSQIZM/AGvu0Q9pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.2",
+        "joi": "^18.0.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2262,6 +4046,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -2362,10 +4163,94 @@
         "node": ">=8"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/zod": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.9.tgz",
-      "integrity": "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqm",
-  "version": "0.5.11",
+  "version": "0.6.0",
   "description": "A lightweight and flexible query maker library for building raw SQL queries in JavaScript.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,14 +13,14 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts --format esm",
+    "build:dev": "tsup --config tsup.config.ts --watch --format esm",
+    "start:dev": "nodemon --watch 'dist' --exec 'wait-on dist/index.mjs && node dist/index.mjs'",
+    "dev": "concurrently \"npm run build:dev\" \"npm run start:dev\"",
     "start": "node dist/index.js",
     "build:prod": "tsup --config tsup.config.ts",
-    "watch": "tsup --config tsup.config.ts --watch",
-    "publish:prod": "npm run build:prod && npm publish --access public",
-    "publish:rc": "npm run build:prod && npm publish --tag rc --access public",
-    "publish:beta": "npm run build:prod && npm publish --tag beta --access public",
-    "publish:alpha": "npm run build:prod && npm publish --tag alpha --access public",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "files": [
     "dist",
@@ -51,13 +51,18 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@swc/core": "^1.13.5",
+    "@vitest/coverage-v8": "^3.2.4",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "concurrently": "^9.2.1",
+    "nodemon": "^3.1.10",
     "terser": "^5.44.0",
     "tslib": "^2.8.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
-    "zod": "^4.1.9"
+    "vitest": "^3.2.4",
+    "wait-on": "^9.0.1",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "ts-pattern": "^5.8.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,21 @@ importers:
       '@swc/core':
         specifier: ^1.13.5
         version: 1.13.5
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(terser@5.44.0))
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      nodemon:
+        specifier: ^3.1.10
+        version: 3.1.10
       terser:
         specifier: ^5.44.0
         version: 5.44.0
@@ -29,15 +38,46 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@swc/core@1.13.5)(typescript@5.9.2)
+        version: 8.5.0(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(terser@5.44.0)
+      wait-on:
+        specifier: ^9.0.1
+        version: 9.0.1
       zod:
-        specifier: ^4.1.9
-        version: 4.1.9
+        specifier: ^4.1.11
+        version: 4.1.11
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
@@ -195,9 +235,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.3':
+    resolution: {integrity: sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -324,6 +388,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/core-darwin-arm64@1.13.5':
     resolution: {integrity: sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==}
     engines: {node: '>=10'}
@@ -399,11 +466,55 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/validator@13.15.3':
     resolution: {integrity: sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==}
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -429,11 +540,39 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.5:
+    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -448,6 +587,26 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -458,6 +617,10 @@ packages:
   class-validator@0.14.2:
     resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -465,12 +628,24 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -492,6 +667,18 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -501,10 +688,40 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -515,35 +732,140 @@ packages:
       picomatch:
         optional: true
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  joi@18.0.1:
+    resolution: {integrity: sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==}
+    engines: {node: '>= 20'}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   libphonenumber-js@1.12.17:
     resolution: {integrity: sha512-bsxi8FoceAYR/bjHcLYc2ShJ/aVAzo5jaxAYiMHF0BD+NTp47405CGuPNKYpw+lHadN9k/ClFGc9X5vaZswIrA==}
@@ -562,15 +884,46 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -584,6 +937,20 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nodemon@3.1.10:
+    resolution: {integrity: sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -603,8 +970,16 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -635,13 +1010,31 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -652,6 +1045,14 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -660,9 +1061,24 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -675,6 +1091,12 @@ packages:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -692,15 +1114,34 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   terser@5.44.0:
     resolution: {integrity: sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==}
     engines: {node: '>=10'}
     hasBin: true
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -709,12 +1150,35 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -759,9 +1223,90 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
+
   validator@13.15.15:
     resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
     engines: {node: '>= 0.10'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  wait-on@9.0.1:
+    resolution: {integrity: sha512-noeCAI+XbqWMXY23sKril0BSURhuLYarkVXwJv1uUWwoojZJE7pmX3vJ7kh7SZaNgPGzfsCSQIZM/AGvu0Q9pA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -774,6 +1319,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -782,10 +1332,42 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  zod@4.1.9:
-    resolution: {integrity: sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==}
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.28.4':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@babel/types@7.28.4':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.25.9':
     optional: true
@@ -865,6 +1447,22 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.3': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -873,6 +1471,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -959,6 +1559,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.50.1':
     optional: true
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/core-darwin-arm64@1.13.5':
     optional: true
 
@@ -1011,9 +1613,76 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/validator@13.15.3': {}
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(terser@5.44.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.5
+      debug: 4.4.1(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(terser@5.44.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(terser@5.44.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.6(terser@5.44.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.19
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   acorn@8.15.0: {}
 
@@ -1029,11 +1698,45 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
+
+  asynckit@0.4.0: {}
+
+  axios@1.12.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   balanced-match@1.0.2: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
 
@@ -1043,6 +1746,38 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   chokidar@4.0.3:
     dependencies:
@@ -1056,15 +1791,36 @@ snapshots:
       libphonenumber-js: 1.12.17
       validator: 13.15.15
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -1076,15 +1832,44 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
+
+  deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.9:
     optionalDependencies:
@@ -1115,9 +1900,21 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
 
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.2.2: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -1125,13 +1922,49 @@ snapshots:
       mlly: 1.8.0
       rollup: 4.50.1
 
+  follow-redirects@1.15.11: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.4.5:
     dependencies:
@@ -1142,9 +1975,62 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  gopd@1.2.0: {}
+
+  has-flag@3.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-escaper@2.0.2: {}
+
+  ignore-by-default@1.0.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.1(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jackspeak@3.4.3:
     dependencies:
@@ -1152,7 +2038,19 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  joi@18.0.1:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.3
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.0.0
+
   joycon@3.1.1: {}
+
+  js-tokens@9.0.1: {}
 
   libphonenumber-js@1.12.17: {}
 
@@ -1164,15 +2062,43 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
+  lodash@4.17.21: {}
+
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -1191,6 +2117,23 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
+  nodemon@3.1.10:
+    dependencies:
+      chokidar: 3.6.0
+      debug: 4.4.1(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 7.7.2
+      simple-update-notifier: 2.0.0
+      supports-color: 5.5.0
+      touch: 3.1.1
+      undefsafe: 2.0.5
+
+  normalize-path@3.0.0: {}
+
   object-assign@4.1.1: {}
 
   package-json-from-dist@1.0.1: {}
@@ -1204,7 +2147,11 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
 
@@ -1216,13 +2163,31 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-from-env@1.1.0: {}
+
+  pstree.remy@1.1.8: {}
 
   punycode@2.3.1: {}
 
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
   readdirp@4.1.2: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -1253,13 +2218,29 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  semver@7.7.2: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -1271,6 +2252,10 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -1292,6 +2277,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -1302,12 +2291,30 @@ snapshots:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   terser@5.44.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   thenify-all@1.6.0:
     dependencies:
@@ -1317,12 +2324,26 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  touch@3.1.1: {}
 
   tr46@1.0.1:
     dependencies:
@@ -1336,18 +2357,18 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@swc/core@1.13.5)(typescript@5.9.2):
+  tsup@8.5.0(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       esbuild: 0.25.9
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)
       resolve-from: 5.0.0
       rollup: 4.50.1
       source-map: 0.8.0-beta.0
@@ -1357,6 +2378,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.13.5
+      postcss: 8.5.6
       typescript: 5.9.2
     transitivePeerDependencies:
       - jiti
@@ -1368,7 +2390,91 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  undefsafe@2.0.5: {}
+
   validator@13.15.15: {}
+
+  vite-node@3.2.4(terser@5.44.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(terser@5.44.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(terser@5.44.0):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+      terser: 5.44.0
+
+  vitest@3.2.4(terser@5.44.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(terser@5.44.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.1(supports-color@5.5.0)
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(terser@5.44.0)
+      vite-node: 3.2.4(terser@5.44.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  wait-on@9.0.1:
+    dependencies:
+      axios: 1.12.2
+      joi: 18.0.1
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
 
   webidl-conversions@4.0.2: {}
 
@@ -1382,6 +2488,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -1394,4 +2505,18 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
-  zod@4.1.9: {}
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zod@4.1.11: {}

--- a/src/cteMaker.test.ts
+++ b/src/cteMaker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import CteMaker, { Cte } from "./cteMaker.js";
+import Query from "./queryMaker.js";
+
+describe('CTE Maker', () => {
+  it('should create CTEs correctly', () => {
+    const cteMaker = new CteMaker();
+
+    const cte1 = cteMaker.addCte(
+      new Cte().as('cte1').withQuery(Query.select.from('users').select('*'))
+    );
+
+    const cte2 = cteMaker.addCtes([
+      new Cte('cte2', Query.select.from('orders').select('*')).recursive()
+    ]);
+
+    const query = Query.select
+      .from('test')
+      .with(cte1)
+      .with(cte2)
+      .select(['cte1.*', 'cte2.*'])
+      .build();
+
+    expect(query.text)
+      .toBe('WITH cte1 AS (\nSELECT\n "*"\nFROM "users"\n), RECURSIVE cte2 AS (\nSELECT\n "*"\nFROM "orders"\n)\nSELECT\n "cte1"."*",\n "cte2"."*"\nFROM "test"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should handle no CTEs gracefully', () => {
+    const cteMaker = new CteMaker();
+    expect(cteMaker.build().text).toBe('');
+  });
+});

--- a/src/deepEqual.test.ts
+++ b/src/deepEqual.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import deepEqual from "./deepEqual.js";
+
+
+describe('Deep Equal', () => {
+  it('should be able to compare deep equality of numbers', () => {
+    const isEqual = deepEqual(1, 1);
+    const isNotEqual = deepEqual(1, 2);
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare deep equality of strings', () => {
+    const isEqual = deepEqual('hello', 'hello');
+    const isNotEqual = deepEqual('hello', 'world');
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare deep equality of booleans', () => {
+    const isEqual = deepEqual(true, true);
+    const isNotEqual = deepEqual(true, false);
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare deep equality of arrays', () => {
+    const isEqual = deepEqual([1, 2, 3], [1, 2, 3]);
+    const isNotEqual = deepEqual([1, 2, 3], [1, 2, 4]);
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare length of arrays', () => {
+    const isNotEqual = deepEqual([1, 2, 3], [1, 2, 3, 4]);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare deep equality of objects', () => {
+    const isEqual = deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 });
+    const isNotEqual = deepEqual({ a: 1, b: 2 }, { a: 1, b: 3 });
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare nested objects', () => {
+    const isEqual = deepEqual({ a: { b: 2 } }, { a: { b: 2 } });
+    const isNotEqual = deepEqual({ a: { b: 2 } }, { a: { b: 3 } });
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare null and undefined', () => {
+    const isEqualNull = deepEqual(null, null);
+    const isEqualUndefined = deepEqual(undefined, undefined);
+    const isNotEqual = deepEqual(null, undefined);
+
+    expect(isEqualNull).toBe(true);
+    expect(isEqualUndefined).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare different types', () => {
+    const isNotEqual1 = deepEqual(1, '1');
+    const isNotEqual2 = deepEqual(true, 1);
+    const isNotEqual3 = deepEqual({}, []);
+
+    expect(isNotEqual1).toBe(false);
+    expect(isNotEqual2).toBe(false);
+    expect(isNotEqual3).toBe(false);
+  });
+
+  it('should be able to compare complex nested structures', () => {
+    const obj1 = {
+      a: 1,
+      b: [1, 2, { c: 3 }],
+      d: { e: { f: 4 } }
+    };
+    const obj2 = {
+      a: 1,
+      b: [1, 2, { c: 3 }],
+      d: { e: { f: 4 } }
+    };
+    const obj3 = {
+      a: 1,
+      b: [1, 2, { c: 4 }],
+      d: { e: { f: 4 } }
+    };
+
+    const isEqual = deepEqual(obj1, obj2);
+    const isNotEqual = deepEqual(obj1, obj3);
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+
+  it('should be able to compare functions by signature', () => {
+    const func1 = function (a: number, b: string): number { return a - +b };
+    const func2 = function (a: number, b: string): number { return a - +b };
+    const func3 = function (a: number): number { return a };
+
+    const isEqual = deepEqual(func1, func2);
+    const isNotEqual = deepEqual(func1, func3);
+
+    expect(isEqual).toBe(true);
+    expect(isNotEqual).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,21 +2,6 @@ import Query from "./queryMaker.js";
 import Statement from "./statementMaker.js";
 import CteMaker from "./cteMaker.js";
 
-let showedAlready = false;
-
-if (!showedAlready) {
-  console.log([
-    "Help us with some questions.",
-    "Access our repo and open an issue!",
-    "https://github.com/NickRMD/queryMaker/issues",
-    "We need your feedback on the following questions:",
-    "\t1. Escaping should be done in this library or in the database driver?",
-    "\t2. Should we support named parameters?",
-    "Thank you for your help!"
-  ].join("\n"));
-  showedAlready = true;
-}
-
 export {
   Query,
   Statement,

--- a/src/queryKinds/delete.test.ts
+++ b/src/queryKinds/delete.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+import DeleteQuery from "./delete.js";
+import Statement from "../statementMaker.js";
+import { Cte } from "../cteMaker.js";
+import SelectQuery from "./select.js";
+
+describe('Delete Query', () => {
+  it('should generate correct DELETE SQL', () => {
+    const query = new DeleteQuery('users')
+      .where(
+        new Statement()
+          .and('id = ?', [1])
+      )
+      .build();
+
+    expect(query.text).toBe('DELETE FROM "users"\n WHERE (id = $1)');
+    expect(query.values).toEqual([1]);
+
+    const query2 = new DeleteQuery('users', 'u')
+      .where('u.id = ?', 2)
+      .build();
+
+    expect(query2.text).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)');
+    expect(query2.values).toEqual([2]);
+  });
+
+  it('should handle using other tables', () => {
+    const query = new DeleteQuery('users', 'u')
+      .using({
+        table: 'teams',
+        alias: 't'
+      })
+      .where(
+        new Statement()
+          .and('u.team_id = t.id')
+          .and('t.active = ?', [true])
+      )
+      .build();
+
+    expect(query.text).toBe('DELETE FROM "users" AS u\n USING "teams" AS t\n WHERE (u.team_id = t.id) AND (t.active = $1)');
+    expect(query.values).toEqual([true]);
+
+    const query2 = new DeleteQuery('users', 'u')
+      .using('teams t')
+      .where(
+        new Statement()
+          .and('u.team_id = t.id')
+          .and('t.active = ?', [true])
+      )
+      .build();
+
+    expect(query2.text).toBe('DELETE FROM "users" AS u\n USING "teams" AS t\n WHERE (u.team_id = t.id) AND (t.active = $1)');
+    expect(query2.values).toEqual([true]);
+
+    const query3 = new DeleteQuery('users', 'u')
+      .using([
+        { table: 'teams', alias: 't' },
+        { table: 'departments', alias: 'd' }
+      ])
+      .where(
+        new Statement()
+          .and('u.team_id = t.id')
+          .and('t.department_id = d.id')
+          .and('d.active = ?', [true])
+      )
+      .build();
+
+    expect(query3.text).toBe('DELETE FROM "users" AS u\n USING "teams" AS t,\n "departments" AS d\n WHERE (u.team_id = t.id) AND (t.department_id = d.id) AND (d.active = $1)');
+    expect(query3.values).toEqual([true]);
+
+    expect(() => {
+      new DeleteQuery('users', 'u')
+        .using('');
+    }).toThrow('Invalid table name provided to USING clause.');
+  });
+
+  it('should handle setting from after', () => {
+    const query = new DeleteQuery()
+      .from('users', 'u')
+      .build();
+
+    expect(query.text).toBe('DELETE FROM "users" AS u');
+  });
+
+  it('should support useStatement', () => {
+    const query = new DeleteQuery()
+      .from('test')
+      .useStatement(stmt =>
+        stmt.and('id = ?', 1)
+          .or('email = ?', 2)
+      ).build();
+
+    expect(query.text).toBe('DELETE FROM "test"\n WHERE (id = $1) OR (email = $2)');
+    expect(query.values).toEqual([1, 2]);
+
+    let someCondition = false;
+
+    const query2 = new DeleteQuery()
+      .from('test')
+      .useStatement(stmt => {
+        stmt.and('id = ?', 1);
+        if (someCondition) {
+          stmt.or('email = ?', 2);
+        }
+      }).build();
+
+    expect(query2.text).toBe('DELETE FROM "test"\n WHERE (id = $1)');
+    expect(query2.values).toEqual([1]);
+  });
+
+  it('should throw error if no table is specified', () => {
+    expect(() => {
+      new DeleteQuery().build();
+    }).toThrow('No table specified for DELETE query.');
+  });
+
+  it('should support schemas', () => {
+    const query = new DeleteQuery('$schema.users')
+      .addSchema('public')
+      .build();
+
+    expect(query.text).toBe('DELETE FROM public."users"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should support multiple schemas', () => {
+    const query = new DeleteQuery('$schema.users')
+      .using('$schema1.teams t')
+      .schema('public', 'audit')
+      .build();
+
+    expect(query.text).toBe('DELETE FROM public."users"\n USING audit."teams" AS t');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should remove duplicate params when re-analyzing', () => {
+    const query = new DeleteQuery('users')
+      .where(
+        new Statement()
+          .and('id = ?', [1])
+          .or('email = ?', [1])
+          .and('status = ?', 'active')
+      )
+      .build();
+
+    expect(query.text).toBe('DELETE FROM "users"\n WHERE (id = $1) OR (email = $1) AND (status = $2)');
+    expect(query.values).toEqual([1, 'active']);
+  });
+
+  it('should support returning clause', () => {
+    const query = new DeleteQuery('users')
+      .where('id = ?', 1)
+      .returning(['id', 'email'])
+      .build();
+
+    expect(query.text).toBe('DELETE FROM "users"\n WHERE (id = $1)\n RETURNING "id", "email"');
+    expect(query.values).toEqual([1]);
+  });
+
+  it('should support cloning', () => {
+    const original = new DeleteQuery('users')
+      .where('id = ?', 1)
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    const clone = original.clone();
+    clone.where('email = ?', 'some@email.com').returning('biscuit').addReturning(['id', 'email']);
+
+    const originalBuilt = original.build();
+    expect(originalBuilt.text).toBe('DELETE FROM "users"\n WHERE (id = $1)\n RETURNING "id", "email", "biscuit"');
+    expect(originalBuilt.values).toEqual([1]);
+
+    const cloneBuilt = clone.build();
+    expect(cloneBuilt.text).toBe('DELETE FROM "users"\n WHERE (email = $1)\n RETURNING "biscuit", "id", "email"');
+    expect(cloneBuilt.values).toEqual(['some@email.com']);
+  });
+
+  it('should support deep analysis for re-analyzing', () => {
+    const query = new DeleteQuery('users')
+      .where(
+        new Statement()
+          .and('id = ?', [1])
+          .or('email = ?', [1])
+          .and('status = ?', 'active')
+      )
+      .build(true);
+
+    expect(query.text).toBe('DELETE FROM "users"\n WHERE (id = $1) OR (email = $1) AND (status = $2)');
+    expect(query.values).toEqual([1, 'active']);
+  });
+
+  it('should support CTEs', () => {
+    const query = new DeleteQuery('users', 'u')
+      .with(new Cte(
+        'active_teams', 
+        new SelectQuery('teams')
+          .where('active = ?', true)
+          .select(['id', 'name']), false
+      )).using('active_teams at')
+      .where('u.team_id = at.id')
+      .build();
+
+    expect(query.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\n DELETE FROM "users" AS u\n USING "active_teams" AS at\n WHERE (u.team_id = at.id)');
+    expect(query.values).toEqual([true]);
+  });
+
+  it('should support returning it\'s queryDefinition', () => {
+    const query = new DeleteQuery('users', 'u')
+      .with(new Cte(
+        'active_teams', 
+        new SelectQuery('teams')
+          .where('active = ?', true)
+          .select(['id', 'name']), false
+      )).using('active_teams at')
+      .where('u.team_id = at.id');
+
+    expect(query.query).toEqual(query);
+  });
+
+  it('should support invalidating its built query', () => {
+    const query = new DeleteQuery('users', 'u')
+      .where('u.id = ?', 1);
+
+    const firstBuild = query.build();
+    expect(firstBuild.text).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)');
+    expect(firstBuild.values).toEqual([1]);
+
+    query.where('u.name = ?', 'test');
+    query.invalidate();
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('DELETE FROM "users" AS u\n WHERE (u.name = $1)');
+    expect(secondBuild.values).toEqual(['test']);
+  });
+
+  it('should support invalidating with CTEs', () => {
+    const query = new DeleteQuery('users', 'u')
+      .with(new Cte(
+        'active_teams', 
+        new SelectQuery('teams')
+          .where('active = ?', true)
+          .select(['id', 'name']), false
+      )).using('active_teams at')
+      .where('u.team_id = at.id');
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\n DELETE FROM "users" AS u\n USING "active_teams" AS at\n WHERE (u.team_id = at.id)');
+    expect(firstBuild.values).toEqual([true]);
+
+    query.where('u.name = ?', 'test');
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\n DELETE FROM "users" AS u\n USING "active_teams" AS at\n WHERE (u.name = $2)');
+    expect(secondBuild.values).toEqual([true, 'test']);
+  });
+
+  it('should support returning it\'s kind', () => {
+    const query = new DeleteQuery('users', 'u');
+    expect(query.kind).toBe('DELETE');
+  });
+
+  it('should support resetting its state', () => {
+    const query = new DeleteQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    const built = query.build();
+    expect(built.text).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)\n RETURNING "id", "email", "biscuit"');
+    expect(built.values).toEqual([1]);
+
+    query.reset();
+    expect(() => {
+      query.build();
+    }).toThrow('No table specified for DELETE query.');
+  });
+
+  it('should support getting params and getting sql directly', () => {
+    const query = new DeleteQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    expect(query.getParams()).toEqual([1]);
+    query.invalidate();
+    expect(query.toSQL()).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)\n RETURNING "id", "email", "biscuit"');
+
+    expect(query.getParams()).toEqual([1]);
+    expect(query.toSQL()).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)\n RETURNING "id", "email", "biscuit"');
+  });
+});

--- a/src/queryKinds/insert.test.ts
+++ b/src/queryKinds/insert.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import InsertQuery from "./insert.js";
+import SelectQuery from "./select.js";
+import { Cte } from "../cteMaker.js";
+
+describe('Insert Query', () => {
+  
+  it('should generate correct INSERT SQL', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 })
+      .build();
+
+    expect(query.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+    expect(query.values).toEqual(['John', 30]);
+
+    const query2 = new InsertQuery()
+      .into('users')
+      .values([
+        { column: 'name', value: 'Jane' },
+        { column: 'age', value: 25 }
+      ])
+      .build();
+
+    expect(query2.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+    expect(query2.values).toEqual(['Jane', 25]);
+  });
+
+  it('should generate INSERT SQL with RETURNING clause', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'Alice', age: 28 })
+      .returning(['id', 'name'])
+      .returning('id')
+      .addReturning('name')
+      .addReturning(['age'])
+      .build();
+
+    expect(query.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)\nRETURNING "id", "name", "age"');
+    expect(query.values).toEqual(['Alice', 28]);
+  });
+
+  it('should generate INSERT SQL from SELECT query', () => {
+    const selectQuery = new SelectQuery('employees')
+      .select(['name', 'age'])
+      .where('age > ?', 30);
+
+    const query = new InsertQuery('users')
+      .columns('name', 'age')
+      .fromSelect(selectQuery)
+      .build();
+
+    expect(query.text).toBe('INSERT INTO "users" ("name", "age")\nSELECT\n "name",\n "age"\nFROM "employees"\nWHERE (age > $1)');
+    expect(query.values).toEqual([30]);
+  });
+
+  it('should error when no values or select query provided', () => {
+    expect(() => {
+      new InsertQuery('users').build();
+    }).toThrow('No values or SELECT query specified for INSERT query.');
+  });
+
+  it('should error when no table specified', () => {
+    expect(() => {
+      new InsertQuery().values({ name: 'John' }).build();
+    }).toThrow('No table specified for INSERT query.');
+  });
+
+  it('should return its kind', () => {
+    const query = new InsertQuery('users');
+    expect(query.kind).toBe('INSERT');
+  });
+
+  it('should reset its state', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 })
+      .returning(['id', 'name']);
+
+    const built = query.build();
+    expect(built.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)\nRETURNING "id", "name"');
+    expect(built.values).toEqual(['John', 30]);
+
+    query.reset();
+    expect(() => {
+      query.build();
+    }).toThrow('No table specified for INSERT query.');
+  });
+
+  it('should invalidate its built query', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 })
+      .returning(['id', 'name']);
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)\nRETURNING "id", "name"');
+    expect(firstBuild.values).toEqual(['John', 30]);
+
+    query.values({ name: 'Jane', age: 25 });
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)\nRETURNING "id", "name"');
+    expect(secondBuild.values).toEqual(['Jane', 25]);
+  });
+
+  it('should return sql and params directly', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 });
+
+    expect(query.toSQL()).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+    query.invalidate();
+    expect(query.getParams()).toEqual(['John', 30]);
+
+    expect(query.toSQL()).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+    expect(query.getParams()).toEqual(['John', 30]);
+  });
+
+  it('should support cloning itself', () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 })
+      .returning(['id', 'name']);
+
+    const clone = query.clone();
+    expect(clone).not.toBe(query);
+    expect(clone.build()).toEqual(query.build());
+
+    clone.values({ name: 'Jane', age: 25 });
+    clone.invalidate();
+
+    expect(clone.build().values).toEqual(['Jane', 25]);
+    expect(query.build().values).toEqual(['John', 30]);
+  });
+
+  it('should support CTEs', () => {
+    const query = new InsertQuery('users')
+      .with(new Cte(
+        'recent_employees',
+        new SelectQuery('employees').where('hired_at > ?', '2023-01-01').select(['name', 'age']),
+        false
+      ))
+      .columns('name', 'age')
+      .fromSelect(new SelectQuery('recent_employees').select(['name', 'age']))
+      .returning(['id', 'name']);
+
+    const built = query.build();
+    expect(built.text).toBe('WITH recent_employees AS (\nSELECT\n "name",\n "age"\nFROM "employees"\nWHERE (hired_at > $1)\n) \nINSERT INTO "users" ("name", "age")\nSELECT\n "name",\n "age"\nFROM "recent_employees"\nRETURNING "id", "name"');
+    expect(built.values).toEqual(['2023-01-01']);
+  });
+
+  it('should support invalidating with CTEs', () => {
+    const query = new InsertQuery('users')
+      .with(new Cte(
+        'recent_employees',
+        new SelectQuery('employees').where('hired_at > ?', '2023-01-01').select(['name', 'age']),
+        false
+      ))
+      .columns('name', 'age')
+      .fromSelect(new SelectQuery('recent_employees').select(['name', 'age']))
+      .returning(['id', 'name']);
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('WITH recent_employees AS (\nSELECT\n "name",\n "age"\nFROM "employees"\nWHERE (hired_at > $1)\n) \nINSERT INTO "users" ("name", "age")\nSELECT\n "name",\n "age"\nFROM "recent_employees"\nRETURNING "id", "name"');
+    expect(firstBuild.values).toEqual(['2023-01-01']);
+
+    query.with(new Cte(
+      'recent_employees',
+      new SelectQuery('employees').where('hired_at > ?', '2024-01-01').select(['name', 'age']),
+      false
+    ));
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('WITH recent_employees AS (\nSELECT\n "name",\n "age"\nFROM "employees"\nWHERE (hired_at > $1)\n) \nINSERT INTO "users" ("name", "age")\nSELECT\n "name",\n "age"\nFROM "recent_employees"\nRETURNING "id", "name"');
+    expect(secondBuild.values).toEqual(['2024-01-01']);
+  });
+
+});

--- a/src/queryKinds/insert.ts
+++ b/src/queryKinds/insert.ts
@@ -1,6 +1,7 @@
 import CteMaker, { Cte } from "../cteMaker.js";
 import SqlEscaper from "../sqlEscaper.js";
 import ColumnValue from "../types/ColumnValue.js";
+import QueryKind from "../types/QueryKind.js";
 import QueryDefinition from "./query.js";
 import SelectQuery from "./select.js";
 
@@ -18,10 +19,6 @@ export default class InsertQuery extends QueryDefinition {
   private selectQuery: SelectQuery | null = null;
   /** The fields to be returned after the insert operation. */
   private returningFields: string[] = [];
-  /** The final built SQL query string. */
-  private builtQuery: string | null = null;
-  /** Optional Common Table Expressions (CTEs) for the query. */
-  private ctes: CteMaker | null = null;
 
   /**
     * Creates an instance of InsertQuery.
@@ -29,7 +26,7 @@ export default class InsertQuery extends QueryDefinition {
     */
   constructor(table?: string) {
     super();
-    this.table = SqlEscaper.escapeTableName(table || '', this.flavor);
+    this.table = table ? SqlEscaper.escapeTableName(table, this.flavor) : '';
   }
 
   /**
@@ -84,6 +81,19 @@ export default class InsertQuery extends QueryDefinition {
   }
 
   /**
+    * Specifies the columns to be inserted without associated values.
+    * This is useful when inserting data from a SELECT query.
+    * @param columns - The names of the columns to be inserted.
+    * @returns The current InsertQuery instance for method chaining.
+    */
+  public columns(...columns: string[]): this {
+    this.columnValues = columns.map(column => ({ 
+      column: SqlEscaper.escapeIdentifier(column, this.flavor), value: undefined 
+    }));
+    return this;
+  }
+
+  /**
     * Specifies a SELECT query to insert data from.
     * This allows inserting records based on the results of another query.
     * @param query - The SELECT query to insert data from.
@@ -108,12 +118,28 @@ export default class InsertQuery extends QueryDefinition {
     return this;
   }
 
+  /**
+    * Adds fields to the existing RETURNING clause.
+    * @param fields - A single field or an array of fields to be added to the RETURNING clause.
+    * @returns The current InsertQuery instance for method chaining.
+    */
+  public addReturning(fields: string | string[]): this {
+    if (Array.isArray(fields)) {
+      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers(fields, this.flavor));
+    } else {
+      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers([fields], this.flavor));
+    }
+    return this;
+  }
+
   /** 
     * Creates a deep clone of the current InsertQuery instance.
     * @returns A new InsertQuery instance with the same properties as the original.
     */
-  public clone(): QueryDefinition {
-    const cloned = new InsertQuery(this.table);
+  public clone(): InsertQuery {
+    const cloned = new InsertQuery();
+    cloned.table = this.table;
+    cloned.schemas = [...this.schemas];
     cloned.columnValues = JSON.parse(JSON.stringify(this.columnValues));
     cloned.selectQuery = this.selectQuery ? this.selectQuery.clone() : null;
     cloned.returningFields = [...this.returningFields];
@@ -125,24 +151,8 @@ export default class InsertQuery extends QueryDefinition {
     * This an INSERT query.
     * @returns The kind of SQL operation, which is 'INSERT' for this class.
     */
-  public get kind(): 'INSERT' | 'UPDATE' | 'DELETE' | 'SELECT' {
-    return 'INSERT';
-  }
-
-  /**
-    * Indicates whether the query has been built and is ready for execution.
-    * @returns True if the query has been built; otherwise, false.
-    */
-  public get isDone(): boolean {
-    return this.builtQuery !== null;
-  }
-
-  /** 
-    * Provides access to the current InsertQuery instance.
-    * @returns The current InsertQuery instance.
-    */
-  public get query(): QueryDefinition {
-    return this;
+  public get kind() {
+    return QueryKind.INSERT;
   }
 
   /** 
@@ -165,6 +175,7 @@ export default class InsertQuery extends QueryDefinition {
     */
   public reset(): void {
     this.table = '';
+    this.schemas = [];
     this.columnValues = [];
     this.selectQuery = null;
     this.returningFields = [];
@@ -176,7 +187,7 @@ export default class InsertQuery extends QueryDefinition {
     * Retrieves the parameters associated with the query.
     * @returns An array of parameters for the query.
     */
-  public getParams(): any[] {
+  private getInternalParams(): any[] {
     if (!this.builtQuery) this.build();
     let params: any[] = [];
     if (this.columnValues.length > 0) {
@@ -188,6 +199,16 @@ export default class InsertQuery extends QueryDefinition {
       params = [...this.ctes.build().values, ...params];
     }
     return params;
+  }
+
+  /** 
+    * Retrieves the parameters associated with the query, building the query if necessary.
+    * @returns An array of parameters for the query.
+    */
+  public getParams(): any[] {
+    if (!this.builtQuery) this.build();
+    if (!this.builtParams) throw new Error('Failed to build query parameters.');
+    return this.builtParams;
   }
 
   /** 
@@ -247,12 +268,13 @@ export default class InsertQuery extends QueryDefinition {
 
     const analyzed = this.reAnalyzeParsedQueryForDuplicateParams(
       this.builtQuery,
-      [...cteValues, ...this.getParams()],
+      [...cteValues, ...this.getInternalParams()],
       deepAnalysis
     );
 
     this.builtQuery = analyzed.text;
-    return { text: this.builtQuery, values: analyzed.values };
+    this.builtParams = analyzed.values;
+    return { text: this.builtQuery, values: this.builtParams };
   }
 
   /** 
@@ -260,6 +282,9 @@ export default class InsertQuery extends QueryDefinition {
     * @returns The SQL query string.
     */
   public toSQL(): string {
-    return this.build().text;
+    if (!this.builtQuery) this.build();
+    if (!this.builtQuery) throw new Error('Failed to build query.');
+
+    return this.builtQuery;
   }
 }

--- a/src/queryKinds/query.test.ts
+++ b/src/queryKinds/query.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import SelectQuery from "./select.js";
+import sqlFlavor from "../types/sqlFlavor.js";
+import UpdateQuery from "./update.js";
+import InsertQuery from "./insert.js";
+import DeleteQuery from "./delete.js";
+import z from "zod";
+import { IsDefined, IsNumber, IsString } from "class-validator";
+import { Transform } from "class-transformer";
+
+
+describe('Query Definition', () => {
+  it('should be able to set sql flavor', () => {
+    const query = new SelectQuery()
+      .from('users')
+      .sqlFlavor(sqlFlavor.mysql);
+
+    expect((query as any as { flavor: sqlFlavor }).flavor).toBe(sqlFlavor.mysql);
+  });
+
+  it('should build explain', () => {
+    const query = new UpdateQuery('users')
+      .set({ name: 'John' })
+      .where('id = ?', 1)
+      .buildExplain();
+
+    expect(query.text).toBe('EXPLAIN UPDATE "users"\nSET "name" = $1\nWHERE (id = $2)');
+    expect(query.values).toEqual(['John', 1]);
+  });
+
+  it('should build explain analyze', () => {
+    const query = new UpdateQuery('users')
+      .set({ name: 'John' })
+      .where('id = ?', 1)
+      .buildExplainAnalyze();
+
+    expect(query.text).toBe('EXPLAIN ANALYZE UPDATE "users"\nSET "name" = $1\nWHERE (id = $2)');
+    expect(query.values).toEqual(['John', 1]);
+  });
+
+  it('should build reanalyze parsed query', () => {
+    const query = new UpdateQuery('users')
+      .set({ name: 'John' })
+      .where('id = ?', 'John')
+      .buildReanalyze();
+
+    expect(query.text).toBe('UPDATE "users"\nSET "name" = $1\nWHERE (id = $1)');
+    expect(query.values).toEqual(['John']);
+  });
+
+  it('should support executing with function or object', async () => {
+    const query = new InsertQuery('users')
+      .values({ name: 'John', age: 30 });
+
+    const executorFunction = async (text: string, values: any[]) => {
+      expect(text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+      expect(values).toEqual(['John', 30]);
+      return [{ id: 1, name: 'John', age: 30 }];
+    }
+
+    const result = await query.execute(executorFunction);
+    expect(result).toEqual([{ id: 1, name: 'John', age: 30 }]);
+
+    const executorObject = {
+      query: async (text: string, values: any[]) => {
+        expect(text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+        expect(values).toEqual(['John', 30]);
+        return [{ id: 1, name: 'John', age: 30 }];
+      }
+    };
+
+    const result2 = await query.execute(executorObject);
+    expect(result2).toEqual([{ id: 1, name: 'John', age: 30 }]);
+
+    const executorObjectWithManager = {
+      manager: {
+        query: async (text: string, values: any[]) => {
+          expect(text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)');
+          expect(values).toEqual(['John', 30]);
+          return [{ id: 1, name: 'John', age: 30 }];
+        }
+      }
+    };
+
+    const result3 = await query.execute(executorObjectWithManager);
+    expect(result3).toEqual([{ id: 1, name: 'John', age: 30 }]);
+
+    await expect(async () => {
+      await query.execute(executorObjectWithManager, true);
+    }).rejects.toThrowError('Invalid query executor provided.');
+  });
+
+  it('should support validating output with zod and class-validator + class-transformer', async () => {
+    const queryZod = new DeleteQuery('users')
+      .where('id = ?', 1)
+      .returning(['id', 'name']);
+
+    const queryClass = queryZod.clone();
+
+    const zodSchema = z.object({
+      id: z.string(),
+      name: z.string()
+    }).transform((obj) => ({
+      id: Number.parseInt(obj.id),
+      name: String(obj.name)
+    }));
+
+    queryZod.validate(zodSchema);
+
+    class User {
+      @IsDefined()
+      @IsNumber()
+      @Transform(({ value }) => Number.parseInt(value))
+      id!: number;
+      @IsDefined()
+      @IsString()
+      @Transform(({ value }) => String(value))
+      name!: string;
+    }
+
+    queryClass.validate(User);
+
+    const executorFunction = async (text: string, values: any[]) => {
+      expect(text).toBe('DELETE FROM "users"\n WHERE (id = $1)\n RETURNING "id", "name"');
+      expect(values).toEqual([1]);
+      return [{ id: '1', name: 'John' }, { id: '2', name: 'Jane' }];
+    }
+
+    const executorFunctionRows = async (text: string, values: any[]) => {
+      expect(text).toBe('DELETE FROM "users"\n WHERE (id = $1)\n RETURNING "id", "name"');
+      expect(values).toEqual([1]);
+      return { rows: [{ id: '1', name: 'John' }, { id: '2', name: 'Jane' }] };
+    }
+
+    const executorObject = {
+      query: executorFunctionRows
+    };
+
+    const executorObjectWithManager = {
+      manager: {
+        query: executorFunctionRows
+      }
+    }
+
+    const resultZod = await queryZod.execute(executorFunction);
+    expect(resultZod).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultClass = await queryClass.execute(executorFunction);
+    expect(resultClass).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultZod2 = await queryZod.execute(executorFunctionRows);
+    expect(resultZod2).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultClass2 = await queryClass.execute(executorFunctionRows);
+    expect(resultClass2).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultZod3 = await queryZod.execute(executorObject);
+    expect(resultZod3).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultClass3 = await queryClass.execute(executorObject);
+    expect(resultClass3).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultZod4 = await queryZod.execute(executorObjectWithManager);
+    expect(resultZod4).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    const resultClass4 = await queryClass.execute(executorObjectWithManager);
+    expect(resultClass4).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+    await expect(async () => {
+      await queryZod.execute(executorObjectWithManager, true);
+    }).rejects.toThrowError('Invalid query executor provided.');
+  });
+
+  it('should change class validator configuration', async () => {
+    const queryClass = new DeleteQuery('users')
+      .where('id = ?', 1)
+      .returning(['id', 'name'])
+      .classValidatorConfig({ whitelist: true, forbidNonWhitelisted: true });
+
+    class User {
+      @IsDefined()
+      @IsNumber()
+      @Transform(({ value }) => Number.parseInt(value))
+      id!: number;
+      @IsDefined()
+      @IsString()
+      @Transform(({ value }) => String(value))
+      name!: string;
+    }
+
+    queryClass.validate(User);
+
+    const executorFunction = async (text: string, values: any[]) => {
+      expect(text).toBe('DELETE FROM "users"\n WHERE (id = $1)\n RETURNING "id", "name"');
+      expect(values).toEqual([1]);
+      return [{ id: '1', name: 'John', extra: 'value' }, { id: '2', name: 'Jane' }];
+    }
+
+    await expect(async () => {
+      await queryClass.execute(executorFunction);
+    }).rejects.toThrowError();
+  });
+});

--- a/src/queryKinds/select.test.ts
+++ b/src/queryKinds/select.test.ts
@@ -17,6 +17,24 @@ describe('Select Query', () => {
     expect(query.values).toEqual([18]);
   });
 
+  // Raw in the sense of not escaped
+  it('should support selecting raw', () => {
+    const query = new SelectQuery('users', 'u')
+      .rawSelect('u.id')
+      .rawSelect(['u.id', 'COUNT(o.id) AS order_count'])
+      .addRawSelect('u.name')
+      .addRawSelect(['u.email', 'u.age'])
+      .where('u.age > ?', 18)
+      .groupBy(['u.id', 'u.name'])
+      .orderBy({ field: 'order_count', direction: 'DESC' })
+      .limit(10)
+      .offset(5)
+      .build();
+
+    expect(query.text).toBe('SELECT\n u.id,\n COUNT(o.id) AS order_count,\n u.name,\n u.email,\n u.age\nFROM "users" AS u\nWHERE (u.age > $1)\nGROUP BY "u"."id", "u"."name"\nORDER BY "order_count" DESC\nLIMIT 10 OFFSET 5');
+    expect(query.values).toEqual([18]);
+  })
+
   it('should handle joins correctly', () => {
     const query = new SelectQuery('orders', 'o')
       .select(['o.id', 'o.total', 'c.name'])

--- a/src/queryKinds/select.test.ts
+++ b/src/queryKinds/select.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it } from "vitest";
+import SelectQuery from "./select.js";
+import Statement from "../statementMaker.js";
+import { Cte } from "../cteMaker.js";
+
+describe('Select Query', () => {
+  it('should generate correct SELECT SQL', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5)
+      .build();
+
+    expect(query.text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(query.values).toEqual([18]);
+  });
+
+  it('should handle joins correctly', () => {
+    const query = new SelectQuery('orders', 'o')
+      .select(['o.id', 'o.total', 'c.name'])
+      .join({
+        type: 'INNER',
+        table: 'customers',
+        alias: 'c',
+        on: 'o.customer_id = c.id'
+      })
+      .where('o.total > ?', 100)
+      .build();
+
+    expect(query.text).toBe('SELECT\n "o"."id",\n "o"."total",\n "c"."name"\nFROM "orders" AS o\nINNER JOIN "customers" c\n ON o.customer_id = c.id\nWHERE (o.total > $1)');
+    expect(query.values).toEqual([100]);
+  });
+
+  it('should handle multiple joins and complex where clauses', () => {
+    const query = new SelectQuery('products', 'p')
+      .select(['p.id', 'p.name', 'c.name AS category_name', 's.name AS supplier_name'])
+      .join([
+        {
+          type: 'LEFT',
+          table: 'categories',
+          alias: 'c',
+          on: 'p.category_id = c.id'
+        },
+        {
+          type: 'INNER',
+          table: 'suppliers',
+          alias: 's',
+          on: 'p.supplier_id = s.id'
+        }
+      ])
+      .where(
+        new Statement()
+          .and('p.price > ?', [20])
+          .and('c.active = ?', [true])
+          .or('s.reliable = ?', [true])
+      )
+      .orderBy([
+        { field: 'p.name', direction: 'ASC' },
+        { column: 'p.price', direction: 'DESC' }
+      ])
+      .limitAndOffset(15, 0)
+      .build();
+
+    expect(query.text).toBe('SELECT\n "p"."id",\n "p"."name",\n "c"."name" AS "category_name",\n "s"."name" AS "supplier_name"\nFROM "products" AS p\nLEFT JOIN "categories" c\n ON p.category_id = c.id\nINNER JOIN "suppliers" s\n ON p.supplier_id = s.id\nWHERE (p.price > $1)\n AND (c.active = $2)\n OR (s.reliable = $2)\nORDER BY "p"."name" ASC, "p"."price" DESC\nLIMIT 15 OFFSET 0');
+    expect(query.values).toEqual([20, true]);
+  });
+
+  it('should handle no selections (select all)', () => {
+    const query = new SelectQuery('employees')
+      .where('department = ?', 'Sales')
+      .orderBy({ column: 'id', direction: 'DESC' })
+      .build();
+
+    expect(query.text).toBe('SELECT\n *\nFROM "employees"\nWHERE (department = $1)\nORDER BY "id" DESC');
+    expect(query.values).toEqual(['Sales']);
+  });
+
+  it('should handle no where clause', () => {
+    const query = new SelectQuery('departments')
+      .select(['id', 'name'])
+      .build();
+
+    expect(query.text).toBe('SELECT\n "id",\n "name"\nFROM "departments"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should handle distinct selection', () => {
+    const query = new SelectQuery('cities')
+      .select(['name'])
+      .distinct()
+      .build();
+
+    expect(query.text).toBe('SELECT\n DISTINCT "name"\nFROM "cities"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should return its kind', () => {
+    const query = new SelectQuery('users');
+    expect(query.kind).toBe('SELECT');
+  });
+
+  it('should be able to select just one field', () => {
+    const query = new SelectQuery('users')
+      .select('email')
+      .build();
+
+    expect(query.text).toBe('SELECT\n "email"\nFROM "users"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should be able to set from after', () => {
+    const query = new SelectQuery()
+      .from('users', 'u')
+      .build();
+
+    expect(query.text).toBe('SELECT\n *\nFROM "users" AS u');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should be able to add selections', () => {
+    const query = new SelectQuery('users')
+      .select('id')
+      .addSelect('name')
+      .addSelect(['email', 'age'])
+      .build();
+
+    expect(query.text).toBe('SELECT\n "id",\n "name",\n "email",\n "age"\nFROM "users"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should support useStatement for where clause', () => {
+    const query = new SelectQuery()
+      .from('test')
+      .useStatement(stmt =>
+        stmt.and('id = ?', 1)
+          .or('email = ?', 2)
+      )
+      .build();
+
+    expect(query.text).toBe('SELECT\n *\nFROM "test"\nWHERE (id = $1)\n OR (email = $2)');
+    expect(query.values).toEqual([1, 2]);
+
+    let someCondition = false;
+
+    const query2 = new SelectQuery()
+      .from('test')
+      .useStatement(stmt => {
+        stmt.and('id = ?', 1);
+        if (someCondition) {
+          stmt.or('email = ?', 2);
+        }
+      })
+      .build();
+
+    expect(query2.text).toBe('SELECT\n *\nFROM "test"\nWHERE (id = $1)');
+    expect(query2.values).toEqual([1]);
+  });
+
+  it('should be set HAVING clause', () => {
+    const query = new SelectQuery('sales')
+      .select(['product_id', 'SUM(amount) AS total_sales'])
+      .groupBy('product_id')
+      .having('SUM(amount) > ?', 1000)
+      .build();
+
+    expect(query.text).toBe('SELECT\n "product_id",\n "SUM(amount)" AS "total_sales"\nFROM "sales"\nGROUP BY "product_id"\nHAVING (SUM(amount) > $1)');
+    expect(query.values).toEqual([1000]);
+  });
+
+  it('should support useHavingStatement', () => {
+    const query = new SelectQuery('sales')
+      .select(['product_id', 'SUM(amount) AS total_sales'])
+      .groupBy('product_id')
+      .useHavingStatement(stmt =>
+        stmt.and('SUM(amount) > ?', 1000)
+          .or('COUNT(id) > ?', 10)
+      )
+      .build();
+
+    expect(query.text).toBe('SELECT\n "product_id",\n "SUM(amount)" AS "total_sales"\nFROM "sales"\nGROUP BY "product_id"\nHAVING (SUM(amount) > $1)\n OR (COUNT(id) > $2)');
+    expect(query.values).toEqual([1000, 10]);
+
+    let someCondition = false;
+
+    const query2 = new SelectQuery('sales')
+      .select(['product_id', 'SUM(amount) AS total_sales'])
+      .groupBy('product_id')
+      .useHavingStatement(stmt => {
+        stmt.and('SUM(amount) > ?', 1000);
+        if (someCondition) {
+          stmt.or('COUNT(id) > ?', 10);
+        }
+      })
+      .build();
+
+    expect(query2.text).toBe('SELECT\n "product_id",\n "SUM(amount)" AS "total_sales"\nFROM "sales"\nGROUP BY "product_id"\nHAVING (SUM(amount) > $1)');
+    expect(query2.values).toEqual([1000]);
+  });
+
+  it('should throw if limit or offset is negative', () => {
+    expect(() => {
+      new SelectQuery('users').limit(-5);
+    }).toThrow('Limit must be a non-negative integer.');
+
+    expect(() => {
+      new SelectQuery('users').offset(-10);
+    }).toThrow('Offset must be a non-negative integer.');
+
+    expect(() => {
+      new SelectQuery('users').limitAndOffset(-1, 5);
+    }).toThrow('Limit must be a non-negative integer.');
+
+    expect(() => {
+      new SelectQuery('users').limitAndOffset(5, -2);
+    }).toThrow('Offset must be a non-negative integer.');
+  });
+
+  it('should be able to reset limit and offset', () => {
+    const query = new SelectQuery('users')
+      .limit(10)
+      .offset(5)
+      .resetLimitOffset()
+      .build();
+
+    expect(query.text).toBe('SELECT\n *\nFROM "users"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should be able to group by select fields', () => {
+    const query = new SelectQuery('employees')
+      .select(['department'])
+      .enableGroupBySelectFields()
+      .build();
+
+    expect(query.text).toBe('SELECT\n "department"\nFROM "employees"\nGROUP BY "department"');
+    expect(query.values).toEqual([]);
+  });
+
+  it('should throw error if no table is specified', () => {
+    expect(() => {
+      new SelectQuery().build();
+    }).toThrow('Table name is required for SELECT query.');
+  });
+
+  it('should be able to union and union all', () => {
+    const query1 = new SelectQuery('table1')
+      .select(['id', 'name'])
+      .where('active = ?', true);
+
+    const query2 = new SelectQuery('table2')
+      .select(['id', 'name'])
+      .where('active = ?', true);
+
+    const unionQuery = query1.union(query2).build();
+
+    expect(unionQuery.text).toBe('SELECT * FROM (\n (SELECT\n  "id",\n  "name"\n FROM "table1"\n WHERE (active = $1))\n\n UNION\n\n (SELECT\n  "id",\n  "name"\n FROM "table2"\n WHERE (active = $1))\n) AS union_subquery');
+    expect(unionQuery.values).toEqual([true]);
+
+    const unionAllQuery = query1.unionAll(query2).build();
+
+    expect(unionAllQuery.text).toBe('SELECT * FROM (\n (SELECT\n  "id",\n  "name"\n FROM "table1"\n WHERE (active = $1))\n\n UNION ALL\n\n (SELECT\n  "id",\n  "name"\n FROM "table2"\n WHERE (active = $1))\n) AS union_subquery');
+    expect(unionAllQuery.values).toEqual([true]);
+
+
+  });
+
+  it('should be able to reset its state', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5);
+
+    const built = query.build();
+    expect(built.text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(built.values).toEqual([18]);
+
+    query.reset();
+    expect(() => {
+      query.build();
+    }).toThrow('Table name is required for SELECT query.');
+  });
+
+  it('should be able to return it\'s query definition', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5);
+
+    expect(query.query).toEqual(query);
+  });
+
+  it('should be able to invalidate its built query', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .having('COUNT(u.id) > ?', 1)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5);
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nHAVING (COUNT(u.id) > $2)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(firstBuild.values).toEqual([18, 1]);
+
+    query.where('u.active = ?', true);
+    query.having('SUM(u.score) > ?', 50);
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.active = $1)\nHAVING (SUM(u.score) > $2)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(secondBuild.values).toEqual([true, 50]);
+  });
+
+  it('should be able to return the sql and params directly', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5);
+
+    expect(query.toSQL()).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    query.invalidate();
+    expect(query.getParams()).toEqual([18]);
+
+    expect(query.toSQL()).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(query.getParams()).toEqual([18]);
+  });
+
+
+  it('should support CTEs', () => {
+    const query = new SelectQuery('users', 'u')
+      .with(new Cte(
+        'active_users',
+        new SelectQuery('users').where('active = ?', true).select(['id', 'name']),
+        false
+      ))
+      .join({
+        type: 'INNER',
+        table: 'active_users',
+        alias: 'au',
+        on: 'u.id = au.id'
+      })
+      .select(['u.id', 'u.name', 'au.name AS active_name'])
+      .where('u.created_at > ?', '2023-01-01')
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(20)
+      .offset(0)
+      .build();
+
+    expect(query.text).toBe('WITH active_users AS (\nSELECT\n "id",\n "name"\nFROM "users"\nWHERE (active = $1)\n)\nSELECT\n "u"."id",\n "u"."name",\n "au"."name" AS "active_name"\nFROM "users" AS u\nINNER JOIN "active_users" au\n ON u.id = au.id\nWHERE (u.created_at > $2)\nORDER BY "u"."name" ASC\nLIMIT 20 OFFSET 0');
+    expect(query.values).toEqual([true, '2023-01-01']);
+  });
+
+  it('should support invalidating with CTEs', () => {
+    const query = new SelectQuery('users', 'u')
+      .with(new Cte(
+        'active_teams', 
+        new SelectQuery('teams')
+          .where('active = ?', true)
+          .select(['id', 'name']), false
+      ))
+      .join({
+        type: 'INNER',
+        table: 'active_teams',
+        alias: 'at',
+        on: 'u.team_id = at.id'
+      })
+      .select(['u.id', 'u.name', 'at.name AS team_name'])
+      .where('u.created_at > ?', '2023-01-01')
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(20)
+      .offset(0);
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\nSELECT\n "u"."id",\n "u"."name",\n "at"."name" AS "team_name"\nFROM "users" AS u\nINNER JOIN "active_teams" at\n ON u.team_id = at.id\nWHERE (u.created_at > $2)\nORDER BY "u"."name" ASC\nLIMIT 20 OFFSET 0');
+    expect(firstBuild.values).toEqual([true, '2023-01-01']);
+
+    query.where('u.active = ?', true);
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\nSELECT\n "u"."id",\n "u"."name",\n "at"."name" AS "team_name"\nFROM "users" AS u\nINNER JOIN "active_teams" at\n ON u.team_id = at.id\nWHERE (u.active = $1)\nORDER BY "u"."name" ASC\nLIMIT 20 OFFSET 0');
+    expect(secondBuild.values).toEqual([true]);
+  });
+
+  it('should support cloning', () => {
+    const query = new SelectQuery('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.age > ?', 18)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5);
+
+    const clone = query.clone();
+    expect(clone).not.toBe(query);
+    expect(clone.build()).toEqual(query.build());
+
+    clone.where('u.active = ?', true);
+    clone.invalidate();
+
+    expect(clone.build().text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.active = $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(clone.build().values).toEqual([true]);
+    expect(query.build().text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.age > $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(query.build().values).toEqual([18]);
+  });
+
+});

--- a/src/queryKinds/select.ts
+++ b/src/queryKinds/select.ts
@@ -2,8 +2,10 @@ import CteMaker, { Cte } from "../cteMaker.js";
 import SqlEscaper from "../sqlEscaper.js";
 import Statement from "../statementMaker.js";
 import Join from "../types/Join.js";
+import QueryKind from "../types/QueryKind.js";
 import OrderBy, { isOrderByField } from "../types/OrderBy.js";
 import QueryDefinition from "./query.js";
+import Union from "./union.js";
 
 /**
   * SelectQuery class represents a SQL SELECT query.
@@ -30,11 +32,6 @@ export default class SelectQuery extends QueryDefinition {
     * The fields to select.
     */
   private selectFields: string[];
-
-  /**
-    * The WHERE clause statement.
-    */
-  private whereStatement: Statement | null = null;
 
   /**
     * The HAVING clause statement.
@@ -72,16 +69,6 @@ export default class SelectQuery extends QueryDefinition {
   private groupBySelectFields: boolean = false;
 
   /**
-    * The built SQL query string.
-    */
-  private builtQuery: string | null = null;
-
-  /**
-    * The CTEs (Common Table Expressions) for the query.
-    */
-  private ctes: CteMaker | null = null;
-
-  /**
     * If true, disables deep analysis of the query for duplicate parameters.
     */
   private disabledAnalysis: boolean = false;
@@ -117,6 +104,28 @@ export default class SelectQuery extends QueryDefinition {
       this.whereStatement.invalidate();
     }
     return this;
+  }
+
+  /**
+    * Resets the WHERE clause parameter offset to zero.
+    * This is useful when reusing the query in different contexts.
+    * @return The current SelectQuery instance for chaining.
+    */
+  public resetWhereOffset(): this {
+    if (this.whereStatement) {
+      this.whereStatement.setOffset(1);
+      this.whereStatement.invalidate();
+    }
+    return this;
+  }
+
+  /**
+    * Invalidates the current state of the query, forcing a rebuild on the next operation.
+    * @returns void
+    */
+  public override invalidate(): void {
+    super.invalidate();
+    if(this.havingStatement) this.havingStatement.invalidate();
   }
 
   /**
@@ -171,6 +180,36 @@ export default class SelectQuery extends QueryDefinition {
     } else {
       this.selectFields = 
         SqlEscaper.escapeSelectIdentifiers([fields], this.flavor);
+    }
+    return this;
+  }
+
+  /**
+    * Sets raw SQL fields to select from, without any escaping.
+    * Can accept a single field as a string or multiple fields as an array of strings.
+    * @param rawFields The raw SQL fields to select.
+    * @returns The current SelectQuery instance for chaining.
+    */
+  public rawSelect(rawFields: string | string[]): this {
+    if (Array.isArray(rawFields)) {
+      this.selectFields = [...rawFields];
+    } else {
+      this.selectFields = [rawFields];
+    }
+    return this;
+  }
+
+  /**
+    * Adds raw SQL fields to the existing selection, without any escaping.
+    * Can accept a single field as a string or multiple fields as an array of strings.
+    * @param rawFields The raw SQL fields to add to the selection.
+    * @returns The current SelectQuery instance for chaining.
+    */
+  public addRawSelect(rawFields: string | string[]): this {
+    if (Array.isArray(rawFields)) {
+      this.selectFields.push(...rawFields);
+    } else {
+      this.selectFields.push(rawFields);
     }
     return this;
   }
@@ -382,9 +421,11 @@ export default class SelectQuery extends QueryDefinition {
     this.groupBys = [];
     this.groupBySelectFields = false;
     this.builtQuery = null;
+    this.builtParams = null;
     this.ctes = null;
     this.havingStatement = null;
     this.disabledAnalysis = false;
+    this.schemas = [];
   }
 
   /**
@@ -395,9 +436,9 @@ export default class SelectQuery extends QueryDefinition {
     */
   public groupBy(fields: string | string[]): this {
     if (Array.isArray(fields)) {
-      this.groupBys.push(...fields);
+      this.groupBys.push(...SqlEscaper.escapeSelectIdentifiers(fields, this.flavor));
     } else {
-      this.groupBys.push(fields);
+      this.groupBys.push(...SqlEscaper.escapeSelectIdentifiers([fields], this.flavor));
     }
     return this;
   }
@@ -413,19 +454,11 @@ export default class SelectQuery extends QueryDefinition {
   }
 
   /**
-    * Gets whether the query has been built.
-    * @returns boolean The built status of the query.
-    */
-  public get isDone(): boolean {
-    return this.builtQuery !== null;
-  }
-
-  /**
     * This is a SELECT query.
     * @returns 'SELECT' The kind of query.
     */
-  public get kind(): 'SELECT' {
-    return 'SELECT';
+  public get kind() {
+    return QueryKind.SELECT;
   }
 
   /**
@@ -434,22 +467,9 @@ export default class SelectQuery extends QueryDefinition {
     * @returns any[] The parameters for the built query.
     */
   public getParams(): any[] {
-    return this.build().values;
-  }
-
-  /**
-    * Invalidates the current built query, forcing a rebuild on the next operation.
-    * Also invalidates any nested statements or CTE queries.
-    * @returns void
-    */
-  public invalidate(): void {
-    this.builtQuery = null;
-    if (this.whereStatement) this.whereStatement.invalidate();
-    if (this.ctes) {
-      for (const cte of this.ctes['ctes']) {
-        cte['query'].invalidate();
-      }
-    }
+    if (!this.builtParams) this.build();
+    if (!this.builtParams) throw new Error("Failed to build query.");
+    return this.builtParams;  
   }
 
   /**
@@ -458,7 +478,12 @@ export default class SelectQuery extends QueryDefinition {
     * @returns A new SelectQuery instance that is a clone of the current instance.
     */
   public clone(): SelectQuery {
-    const cloned = new SelectQuery(this.table, this.tableAlias, this.groupBySelectFields);
+    const cloned = new SelectQuery();
+    cloned.table = this.table;
+    cloned.tableAlias = this.tableAlias;
+    this.groupBySelectFields = this.groupBySelectFields;
+    cloned.flavor = this.flavor;
+    cloned.schemas = [...this.schemas];
     cloned.distinctSelect = this.distinctSelect;
     cloned.selectFields = [...this.selectFields];
     cloned.whereStatement = this.whereStatement ? this.whereStatement.clone() : null;
@@ -476,113 +501,25 @@ export default class SelectQuery extends QueryDefinition {
   }
 
   /**
-    * Makes a UNION ALL of the current query with another SelectQuery.
-    * The resulting query will select all fields from both queries.
-    * Note: The resulting query cannot be cloned.
-    * @param query The SelectQuery to union with the current query.
-    * @returns A new SelectQuery instance representing the UNION ALL of the two queries.
+    * Combines the current SELECT query with another SELECT query using UNION ALL.
+    * @param query The SELECT query to combine with.
+    * @returns A new Union instance representing the combined queries.
     */
-  public unionAll(query: SelectQuery): SelectQuery {
-    let firstQuery;
-    try {
-      firstQuery = this.clone().build();
-    } catch(e) {
-      if (e instanceof Error && e.message.includes("UNION")) {
-        firstQuery = this.build();
-      } else throw e;
-    }
-
-    const secondQuery = query
-      .clone()
-      .build();
-
-    const texts = [firstQuery.text, secondQuery.text];
-    const values = [...firstQuery.values, ...secondQuery.values];
-
-    let paramIndex = 1;
-    let resultTexts: string[] = [];
-    for (const text of texts) {
-      resultTexts.push(text.replace(/\$(\d+)/g, () =>
-        `$${paramIndex++}`
-      ));
-    }
-    const text = resultTexts.join('\nUNION ALL\n'); 
-
-    const unionQuery = new SelectQuery();
-    unionQuery.builtQuery = text;
-    unionQuery.ctes = null;
-    unionQuery.selectFields = ['*'];
-    unionQuery.whereStatement = null;
-    unionQuery.table = '';
-    unionQuery.tableAlias = null;
-    unionQuery.distinctSelect = false;
-    unionQuery.joins = [];
-    unionQuery.orderBys = [];
-    unionQuery.limitCount = null;
-    unionQuery.offsetCount = null;
-    unionQuery.groupBys = [];
-    unionQuery.groupBySelectFields = false;
-    unionQuery.clone = () => {
-      throw new Error("Cannot clone a UNION ALL query.");
-    }
-    unionQuery.build = () => ({ text: text, values: values })
-
-    return unionQuery;
+  public unionAll(query: SelectQuery): Union {
+    return new Union()
+      .add(this)
+      .add(query, 'UNION ALL');
   }
 
   /**
-    * Makes a UNION of the current query with another SelectQuery.
-    * The resulting query will select all fields from both queries, removing duplicates.
-    * Note: The resulting query cannot be cloned.
-    * @param query The SelectQuery to union with the current query.
-    * @returns A new SelectQuery instance representing the UNION of the two queries.
+    * Combines the current SELECT query with another SELECT query using UNION.
+    * @param query The SELECT query to combine with.
+    * @returns A new Union instance representing the combined queries.
     */
-  public union(query: SelectQuery): SelectQuery {
-    let firstQuery;
-    try {
-      firstQuery = this.clone().build();
-    } catch(e) {
-      if (e instanceof Error && e.message.includes("UNION")) {
-        firstQuery = this.build();
-      } else throw e;
-    }
-
-    const secondQuery = query
-      .clone()
-      .build();
-
-    const texts = [firstQuery.text, secondQuery.text];
-    const values = [...firstQuery.values, ...secondQuery.values];
-
-    let paramIndex = 1;
-    let resultTexts: string[] = [];
-    for (const text of texts) {
-      resultTexts.push(text.replace(/\$(\d+)/g, () =>
-        `$${paramIndex++}`
-      ));
-    }
-    const text = resultTexts.join('\nUNION\n'); 
-
-    const unionQuery = new SelectQuery();
-    unionQuery.builtQuery = text;
-    unionQuery.ctes = null;
-    unionQuery.selectFields = ['*'];
-    unionQuery.whereStatement = null;
-    unionQuery.table = '';
-    unionQuery.tableAlias = null;
-    unionQuery.distinctSelect = false;
-    unionQuery.joins = [];
-    unionQuery.orderBys = [];
-    unionQuery.limitCount = null;
-    unionQuery.offsetCount = null;
-    unionQuery.groupBys = [];
-    unionQuery.groupBySelectFields = false;
-    unionQuery.clone = () => {
-      throw new Error("Cannot clone a UNION query.");
-    }
-    unionQuery.build = () => ({ text: text, values: values })
-
-    return unionQuery;
+  public union(query: SelectQuery): Union {
+    return new Union()
+      .add(this)
+      .add(query, 'UNION');
   }
 
   /**
@@ -625,7 +562,7 @@ export default class SelectQuery extends QueryDefinition {
       const onClause = 
         typeof join.on === 'string' ? join.on
         : (() => {
-            join.on.enableWhere();
+            join.on.disableWhere();
             join.on.addOffset(currentOffset);
             const stmt = join.on.build(false);
             currentOffset += stmt.values.length;
@@ -710,7 +647,8 @@ export default class SelectQuery extends QueryDefinition {
         deepAnalysis
       );
       this.builtQuery = analyzed.text;
-      return { text: this.builtQuery, values: analyzed.values };
+      this.builtParams = analyzed.values;
+      return { text: this.builtQuery, values: this.builtParams };
     }
   }
 
@@ -720,14 +658,8 @@ export default class SelectQuery extends QueryDefinition {
     * @returns string The SQL query string.
     */
   public toSQL(): string {
-    return this.build().text;
-  }
-
-  /**
-    * Gets the query definition itself.
-    * @returns QueryDefinition The current SelectQuery instance.
-    */
-  public get query(): QueryDefinition {
-    return this;
+    if (!this.builtQuery) this.build();
+    if (!this.builtQuery) throw new Error("Failed to build query.");
+    return this.builtQuery;
   }
 }

--- a/src/queryKinds/select.ts
+++ b/src/queryKinds/select.ts
@@ -93,6 +93,14 @@ export default class SelectQuery extends QueryDefinition {
   }
 
   /**
+    * Gets the selected columns.
+    * @returns A readonly array of selected column names.
+    */
+  public get columns(): Readonly<string[]> {
+    return this.selectFields;
+  }
+
+  /**
     * Add an offset to the WHERE clause parameters.
     * This is useful when combining multiple statements to ensure parameter indices are correct.
     * @param offset The offset to add to the parameter indices.
@@ -490,8 +498,9 @@ export default class SelectQuery extends QueryDefinition {
     cloned.joins = this.joins.map(j => ({
       type: j.type,
       table: j.table,
+      alias: j.alias,
       on: typeof j.on === "string" ? `${j.on}` : j.on.clone()
-    }));
+    }) as Join);
     cloned.orderBys = [...this.orderBys];
     cloned.limitCount = this.limitCount;
     cloned.offsetCount = this.offsetCount;
@@ -603,7 +612,7 @@ export default class SelectQuery extends QueryDefinition {
     if (this.orderBys.length > 0) {
       const orders = this.orderBys.map(ob => {
         let field = '';
-        if(isOrderByField(ob)) field = ob.field;
+        if(isOrderByField(ob)) field = ob.field
         else field = ob.column;
 
         return `${field} ${ob.direction}`;

--- a/src/queryKinds/union.test.ts
+++ b/src/queryKinds/union.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+import Union from "./union.js";
+import Query from "../queryMaker.js";
+import Statement from "../statementMaker.js";
+
+describe("Union Query", () => {
+  it('should create a UNION query with two SELECT statements', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1", "column2"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1", "column2"])
+      .where("column2 = ?", "value2");
+
+    const unionQuery = new Union()
+      .addMany([
+        {
+          query: select1,
+          type: 'union'
+        }, 
+        {
+          query: select2,
+          type: 'union all'
+        }
+      ])
+      .as('union_table')
+      .build();
+
+    expect(unionQuery.text).toBe('SELECT * FROM (\n (SELECT\n  "column1",\n  "column2"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1",\n  "column2"\n FROM "table2"\n WHERE (column2 = $2))\n) AS union_table');
+    expect(unionQuery.values).toEqual(['value1', 'value2']);
+  });
+
+  it('should create a UNION query with LIMIT and OFFSET', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 IS NOT NULL");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 IS NOT NULL");
+
+    const unionQuery = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union')
+      .as('union_table')
+      .limit(15)
+      .offset(3)
+      .limitAndOffset(10, 5) // This should override the previous limit and offset
+      .build();
+
+    expect(unionQuery.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 IS NOT NULL))\n\n UNION\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 IS NOT NULL))\n) AS union_table\nLIMIT 10\nOFFSET 5');
+    expect(unionQuery.values).toEqual([]);
+  });
+
+  it('should throw if limit or offset is negative', () => {
+    const union = new Union();
+    expect(() => union.limit(-1)).toThrow('Limit must be a non-negative integer.');
+    expect(() => union.offset(-5)).toThrow('Offset must be a non-negative integer.');
+    expect(() => union.limitAndOffset(10, -2)).toThrow('Offset must be a non-negative integer.');
+    expect(() => union.limitAndOffset(-10, 2)).toThrow('Limit must be a non-negative integer.');
+  });
+
+  it('should return raw union query with rawUnion method', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all');
+
+    const rawUnion = union.rawUnion();
+
+    expect(rawUnion.text).toBe('SELECT\n "column1"\nFROM "table1"\nWHERE (column1 = $1)\n\nUNION ALL\n\nSELECT\n "column1"\nFROM "table2"\nWHERE (column1 = $2)');
+    expect(rawUnion.values).toEqual(['value1', 'value2']);
+  });
+
+  it('should throw error when no SELECT queries are added', () => {
+    const union = new Union();
+    expect(() => union.rawUnion()).toThrow('No SELECT queries added to the UNION.');
+    expect(() => union.build()).toThrow('No SELECT queries added to the UNION.');
+  });
+
+  it('should be able to return sql and params directly', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table');
+
+    expect(union.toSQL()).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table');
+    union.invalidate();
+    expect(union.getParams()).toEqual(['value1', 'value2']);
+
+    expect(union.toSQL()).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table');
+    expect(union.getParams()).toEqual(['value1', 'value2']);
+  });
+
+  it('should support resetting its state', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table');
+
+    const built = union.build();
+    expect(built.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table');
+    expect(built.values).toEqual(['value1', 'value2']);
+
+    union.reset();
+    expect(() => union.build()).toThrow('No SELECT queries added to the UNION.');
+  });
+
+  it('should return its kind', () => {
+    const union = new Union();
+    expect(union.kind).toBe('UNION');
+  });
+
+  it('should support adding where clause to the union', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    // Through where
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .where(
+        new Statement()
+          .and("column1 = ?", "finalValue")
+      ).build();
+
+    expect(union.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nWHERE (column1 = $3)');
+    expect(union.values).toEqual(['value1', 'value2', 'finalValue']);
+
+    // Through useStatement
+    const union2 = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .useStatement((stmt) => {
+        stmt.and("column1 = ?", "finalValue");
+      })
+      .build();
+
+    expect(union2.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nWHERE (column1 = $3)');
+    expect(union2.values).toEqual(['value1', 'value2', 'finalValue']);
+  });
+
+  it('should support adding having clause to the union', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    // Through where
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .groupBy('column1')
+      .having(
+        new Statement()
+          .and("column1 = ?", "finalValue")
+      ).build();
+
+    expect(union.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nGROUP BY "column1"\nHAVING (column1 = $3)');
+    expect(union.values).toEqual(['value1', 'value2', 'finalValue']);
+
+    // Through useStatement
+    const union2 = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .addGroupBy('column1')
+      .useHavingStatement((stmt) => {
+        stmt.and("column1 = ?", "finalValue");
+      })
+      .build();
+
+    expect(union2.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nGROUP BY "column1"\nHAVING (column1 = $3)');
+    expect(union2.values).toEqual(['value1', 'value2', 'finalValue']);
+  });
+
+  it('should support group by and order by clauses', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    // One per time
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .groupBy('column1')
+      .addGroupBy('column2')
+      .orderBy({ field: 'column1', direction: 'DESC' })
+      .addOrderBy({ field: 'column2', direction: 'ASC' })
+      .build();
+
+    expect(union.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nGROUP BY "column1", "column2"\nORDER BY "column1" DESC, "column2" ASC');
+    expect(union.values).toEqual(['value1', 'value2']);
+
+    // Multiple at once
+    const union2 = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .groupBy(['column1', 'column2'])
+      .addGroupBy(['column3', 'column4'])
+      .orderBy([
+        { field: 'column1', direction: 'DESC' },
+        { field: 'column2', direction: 'ASC' }
+      ])
+      .addOrderBy([
+        { field: 'column3', direction: 'DESC' },
+        { field: 'column4', direction: 'ASC' }
+      ])
+      .build();
+
+    expect(union2.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nGROUP BY "column1", "column2", "column3", "column4"\nORDER BY "column1" DESC, "column2" ASC, "column3" DESC, "column4" ASC');
+    expect(union2.values).toEqual(['value1', 'value2']);
+  });
+
+  it('should support raw where statement and having statement', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .where("column1 = ?", "finalValue")
+      .groupBy('column1')
+      .having("column1 = ?", "finalValue")
+      .build();
+
+    expect(union.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nWHERE (column1 = $3)\nGROUP BY "column1"\nHAVING (column1 = $3)');
+    expect(union.values).toEqual(['value1', 'value2', 'finalValue']);
+  });
+
+  it('should throw if type of union is invalid', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const union = new Union();
+    expect(() => union.add(select1, 'invalid' as any)).toThrow('Invalid union type. Only \'UNION\' and \'UNION ALL\' are allowed.');
+  });
+
+  it('should support clonning itself', () => {
+    const select1 = Query.select
+      .from("table1")
+      .select(["column1"])
+      .where("column1 = ?", "value1");
+
+    const select2 = Query.select
+      .from("table2")
+      .select(["column1"])
+      .where("column1 = ?", "value2");
+
+    const union = new Union()
+      .add(select1, 'union')
+      .add(select2, 'union all')
+      .as('union_table')
+      .where("column1 = ?", "finalValue")
+      .groupBy('column1')
+      .having("column1 = ?", "finalValue")
+      .limit(10)
+      .offset(5);
+
+    const built = union.build();
+
+    expect(built.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS union_table\nWHERE (column1 = $3)\nGROUP BY "column1"\nHAVING (column1 = $3)\nLIMIT 10\nOFFSET 5');
+    expect(built.values).toEqual(['value1', 'value2', 'finalValue']);
+
+    const clone = union.clone().as('cloned_union_table').limit(20).offset(0);
+    const builtClone = clone.build();
+
+    expect(builtClone.text).toBe('SELECT * FROM (\n (SELECT\n  "column1"\n FROM "table1"\n WHERE (column1 = $1))\n\n UNION ALL\n\n (SELECT\n  "column1"\n FROM "table2"\n WHERE (column1 = $2))\n) AS cloned_union_table\nWHERE (column1 = $3)\nGROUP BY "column1"\nHAVING (column1 = $3)\nLIMIT 20\nOFFSET 0');
+    expect(builtClone.values).toEqual(['value1', 'value2', 'finalValue']);
+
+    // Original should remain unchanged
+    const rebuiltOriginal = union.build();
+    expect(rebuiltOriginal).toEqual(built);
+  });
+
+});

--- a/src/queryKinds/union.ts
+++ b/src/queryKinds/union.ts
@@ -1,0 +1,484 @@
+import Statement from "../statementMaker.js";
+import QueryKind from "../types/QueryKind.js";
+import OrderBy from "../types/OrderBy.js";
+import QueryDefinition from "./query.js";
+import SelectQuery from "./select.js";
+
+/** Allowed types for UnionType */
+export const UnionTypes = {
+  UNION: "UNION",
+  UNION_ALL: "UNION ALL",
+  INTERSECT: "INTERSECT",
+  INTERSECT_ALL: "INTERSECT ALL",
+  EXCEPT: "EXCEPT",
+  EXCEPT_ALL: "EXCEPT ALL",
+} as const;
+
+/** Array of allowed union types for validation */
+const unionTypesArray = Object.values(UnionTypes);
+
+/** Base types for UnionType */
+type UnionTypeBase = typeof UnionTypes[keyof typeof UnionTypes];
+
+/**
+  * UnionType represents the type of SQL UNION operation.
+  */
+export type UnionType = Lowercase<UnionTypeBase> | UnionTypeBase;
+
+/**
+  * Type representing a SELECT query along with its associated union type.
+  */
+export type SelectQueryWithUnionType = {
+  query: SelectQuery;
+  type: UnionType;
+};
+
+/**
+  * Union class represents a SQL UNION operation.
+  * It allows combining multiple SELECT queries into a single result set.
+  * It is basically a wrapper around multiple SelectQuery instances that
+  * creates a SELECT query that is the union of all the provided queries.
+  * It supports adding queries with different union types (UNION or UNION ALL)
+  * and can optionally assign an alias to the resulting union query.
+  */
+export default class Union extends QueryDefinition {
+  /** Needed alias for the union query */
+  private unionAlias: string | null = null;
+
+  /** Limit count for the union query */
+  private limitCount: number | null = null;
+
+  /** Offset count for the union query */
+  private offsetCount: number | null = null;
+
+  /** Array of SelectQuery instances and their corresponding union types */
+  private selectQueries: SelectQueryWithUnionType[] = [];
+
+  /** Order by clauses for the union query */
+  private orderBys: OrderBy[] = [];
+
+  /** Group by clauses for the union query */
+  private groupBys: string[] = [];
+
+  /** Having statement for the union query */
+  private havingStatement: Statement | null = null;
+
+  /**
+    * Make the union without selecting from it
+    * Useful when the raw union is needed as a subquery
+    * @returns An object containing the raw SQL text of the union and its parameter values.
+    */
+  public rawUnion(): { text: string; values: any[] } {
+    if (this.selectQueries.length === 0) {
+      throw new Error('No SELECT queries added to the UNION.');
+    }
+
+    let unionItself: string = '';
+    const values: any[] = [];
+
+    let paramOffset = 1;
+    for (const { query, type } of this.selectQueries) {
+      (query as any).disabledAnalysis = true;
+      query.resetWhereOffset();
+      let builtQuery = query.addWhereOffset(paramOffset - 1).build();
+      unionItself += (unionItself ? `\n\n${type}\n\n` : '') + `${builtQuery.text}`;
+      paramOffset += builtQuery.values.length;
+      values.push(...builtQuery.values);
+    }
+
+    const analyzed = this.reAnalyzeParsedQueryForDuplicateParams(
+      unionItself,
+      values,
+      false
+    );
+
+    return {
+      text: analyzed.text,
+      values: analyzed.values
+    };
+  }
+
+  /**
+    * Assigns an alias to the resulting union query.
+    * @param alias The alias to assign to the union query.
+    * @returns The current Union instance for method chaining.
+    */
+  public as(alias: string): Union {
+    this.unionAlias = alias;
+    return this;
+  }
+
+  /**
+    * Adds a SELECT query to the union with the specified union type.
+    * @param query The SelectQuery instance to add to the union.
+    * @param type The type of union operation ('UNION' or 'UNION ALL'). Defaults to 'UNION ALL'.
+    * @returns The current Union instance for method chaining.
+    * @throws Error if an invalid union type is provided.
+    */
+  public add(query: SelectQuery, type: UnionType = 'UNION ALL'): Union {
+    type = type.toUpperCase() as UnionTypeBase;
+    if (!unionTypesArray.includes(type))
+      throw new Error("Invalid union type. Only 'UNION' and 'UNION ALL' are allowed.");
+
+    this.selectQueries.push({ query, type });
+    return this;
+  }
+
+  /**
+    * Adds multiple SELECT queries to the union.
+    * @param queries An array of objects containing SelectQuery instances and their corresponding union types.
+    * @returns The current Union instance for method chaining.
+    */
+  public addMany(queries: SelectQueryWithUnionType[]): Union {
+    queries.forEach(({ query, type }) => {
+      this.add(query, type);
+    });
+    return this;
+  }
+
+  /**
+    * Adds multiple SELECT queries to the union of the same union type.
+    * @param queries An array of SelectQuery instances to add to the union.
+    * @param type The type of union operation ('UNION' or 'UNION ALL'). Defaults to 'UNION ALL'.
+    * @returns The current Union instance for method chaining.
+    */
+  public addManyOfType(queries: SelectQuery[], type: UnionType = 'UNION ALL'): Union {
+    queries.forEach((query) => {
+      this.add(query, type);
+    });
+    return this;
+  }
+
+  /**
+    * Adds a WHERE clause to the union query.
+    * @param statement The WHERE clause as a Statement instance or a raw SQL string.
+    * @param values Optional parameter values if a raw SQL string is provided.
+    * @returns The current Union instance for method chaining.
+    */
+  public where(statement: Statement | string, ...values: any[]): Union {
+    if (typeof statement === 'string') {
+      statement = new Statement().raw('', statement, ...values);
+    }
+    this.whereStatement = statement;
+    return this;
+  }
+
+  /**
+    * Adds a WHERE clause to the union query using a callback function.
+    * The callback function receives a Statement instance to build the WHERE clause.
+    * @param statement A callback function that takes a Statement instance and returns a Statement or void.
+    * @returns The current Union instance for method chaining.
+    */
+  public useStatement(statement: (stmt: Statement) => Statement | void): Union {
+    const stmt = new Statement();
+    const newStatement = statement(stmt) || stmt;
+
+    this.whereStatement = newStatement;
+    return this;
+  }
+
+  /**
+    * Sets a LIMIT on the number of rows returned by the union query.
+    * @param limit The maximum number of rows to return. Must be a non-negative integer.
+    * @returns The current Union instance for method chaining.
+    * @throws Error if the limit is negative or not an integer.
+    */
+  public limit(limit: number): Union {
+    if (limit < 0 || !Number.isInteger(limit)) {
+      throw new Error('Limit must be a non-negative integer.');
+    }
+    this.limitCount = limit;
+    return this;
+  }
+
+  /**
+    * Sets an OFFSET for the union query.
+    * @param offset The number of rows to skip before starting to return rows. Must be a non-negative integer.
+    * @returns The current Union instance for method chaining.
+    * @throws Error if the offset is negative or not an integer.
+    */
+  public offset(offset: number): Union {
+    if (offset < 0 || !Number.isInteger(offset)) {
+      throw new Error('Offset must be a non-negative integer.');
+    }
+    this.offsetCount = offset;
+    return this;
+  }
+
+  /**
+    * Sets both LIMIT and OFFSET for the union query.
+    * @param limit The maximum number of rows to return. Must be a non-negative integer.
+    * @param offset The number of rows to skip before starting to return rows. Must be a non-negative integer.
+    * @returns The current Union instance for method chaining.
+    * @throws Error if the limit or offset is negative or not an integer.
+    */
+  public limitAndOffset(limit: number, offset: number): Union {
+    return this.limit(limit).offset(offset);
+  }
+
+  /**
+    * Sets the ORDER BY clauses for the union query, replacing any existing clauses.
+    * @param orderBy A single OrderBy object or an array of OrderBy objects.
+    * @returns The current Union instance for method chaining.
+    */
+  public orderBy(orderBy: OrderBy | OrderBy[]): Union {
+    if (Array.isArray(orderBy)) {
+      this.orderBys = orderBy
+    } else {
+      this.orderBys = [orderBy];
+    }
+    return this;
+  }
+
+  /**
+    * Adds ORDER BY clauses to the union query without replacing existing clauses.
+    * @param orderBy A single OrderBy object or an array of OrderBy objects to add.
+    * @returns The current Union instance for method chaining.
+    */
+  public addOrderBy(orderBy: OrderBy | OrderBy[]): Union {
+    if (Array.isArray(orderBy)) {
+      this.orderBys.push(...orderBy)
+    } else {
+      this.orderBys.push(orderBy);
+    }
+    return this;
+  }
+
+  /**
+    * Sets the GROUP BY clauses for the union query, replacing any existing clauses.
+    * @param field A single field name or an array of field names to group by.
+    * @returns The current Union instance for method chaining.
+    */
+  public groupBy(field: string | string[]): Union {
+    if (Array.isArray(field)) {
+      this.groupBys = field
+    } else {
+      this.groupBys = [field];
+    }
+    return this;
+  }
+
+  /**
+    * Adds GROUP BY clauses to the union query without replacing existing clauses.
+    * @param field A single field name or an array of field names to add to the GROUP BY clause.
+    * @returns The current Union instance for method chaining.
+    */
+  public addGroupBy(field: string | string[]): Union {
+    if (Array.isArray(field)) {
+      this.groupBys.push(...field)
+    } else {
+      this.groupBys.push(field);
+    }
+    return this;
+  }
+
+  /**
+    * Adds a HAVING clause to the union query.
+    * @param statement The HAVING clause as a Statement instance or a raw SQL string.
+    * @param values Optional parameter values if a raw SQL string is provided.
+    * @returns The current Union instance for method chaining.
+    */
+  public having(statement: Statement | string, ...values: any[]): Union {
+    if (typeof statement === 'string') {
+      statement = new Statement().raw('', statement, ...values);
+    }
+    this.havingStatement = statement;
+    return this;
+  }
+
+  /**
+    * Adds a HAVING clause to the union query using a callback function.
+    * The callback function receives a Statement instance to build the HAVING clause.
+    * @param statement A callback function that takes a Statement instance and returns a Statement or void.
+    * @returns The current Union instance for method chaining.
+    */
+  public useHavingStatement(statement: (stmt: Statement) => Statement | void): Union {
+    const stmt = new Statement();
+    const newStatement = statement(stmt) || stmt;
+
+    this.havingStatement = newStatement;
+    return this;
+  }
+
+  /**
+    * Builds the final SQL query for the union operation.
+    * It combines all added SELECT queries with their respective union types,
+    * applies any WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, and OFFSET clauses,
+    * and returns the complete SQL text along with the parameter values.
+    * @param deepAnalysis If true, performs a deep analysis to re-index parameters. Defaults to false.
+    * @returns An object containing the final SQL text and an array of parameter values.
+    * @throws Error if no SELECT queries have been added to the union.
+    */
+  public build(deepAnalysis: boolean = false): { text: string; values: any[] } {
+    if (this.selectQueries.length === 0) {
+      throw new Error('No SELECT queries added to the UNION.');
+    }
+
+    let unionItself: string = '';
+    const values: any[] = [];
+
+    // Add offset on each select query to ensure correct parameter indexing
+    let paramOffset = 1;
+    for (const { query, type: unionType } of this.selectQueries) {
+      (query as any).disabledAnalysis = true;
+      query.resetWhereOffset();
+      let builtQuery = query.addWhereOffset(paramOffset - 1).build();
+      builtQuery.text = this.spaceLines(`(${builtQuery.text})`, 1);
+      const type = this.spaceLines(unionType, 1);
+      unionItself += (unionItself ? `\n\n${type}\n\n` : '') + `${builtQuery.text}`;
+      paramOffset += builtQuery.values.length;
+      values.push(...builtQuery.values);
+    }
+
+    let whereClause = '';
+    let whereValues: any[] = [];
+    if (this.whereStatement) {
+      const builtWhere = this.whereStatement
+        .enableWhere()
+        .setOffset(paramOffset)
+        .build();
+      whereClause = builtWhere.statement;
+      whereValues = builtWhere.values;
+    }
+
+    let groupByClause = '';
+    if (this.groupBys.length > 0) {
+      groupByClause = 'GROUP BY ' + this.groupBys.map(gb => `"${gb}"`).join(', ');
+    }
+
+    let havingClause = '';
+    let havingValues: any[] = [];
+    if (this.havingStatement) {
+      const builtHaving = this.havingStatement
+        .disableWhere()
+        .setOffset(paramOffset + whereValues.length)
+        .build();
+      havingClause = 'HAVING ' + builtHaving.statement;
+      havingValues = builtHaving.values;
+    }
+
+    let orderByClause = '';
+    if (this.orderBys.length > 0) {
+      orderByClause = 'ORDER BY ' + this.orderBys.map(ob => {
+        const direction = ob.direction ? ` ${ob.direction.toUpperCase()}` : '';
+        return `"${(ob as any).field || (ob as any).column}"${direction}`;
+      }).join(', ');
+    }
+
+    let limitClause = '';
+    if (this.limitCount !== null) {
+      limitClause = `LIMIT ${this.limitCount}`;
+    }
+
+    let offsetClause = '';
+    if (this.offsetCount !== null) {
+      offsetClause = `OFFSET ${this.offsetCount}`;
+    }
+
+    const union = [
+      'SELECT * FROM (',
+      `${unionItself}\n) AS ${this.unionAlias || 'union_subquery'}`,
+      whereClause,
+      groupByClause,
+      havingClause,
+      orderByClause,
+      limitClause,
+      offsetClause
+    ].filter(part => part.trim() !== '').join('\n');
+
+    const finalValues = [...values, ...whereValues, ...havingValues]; 
+
+    const analyzed = this.reAnalyzeParsedQueryForDuplicateParams(
+      union,
+      finalValues,
+      deepAnalysis
+    );
+
+    this.builtQuery = analyzed.text;
+    this.builtParams = analyzed.values;
+
+    return {
+      text: this.builtQuery,
+      values: this.builtParams
+    };
+  }
+
+  /**
+    * Generates the SQL string for the union query.
+    * If the query has not been built yet, it will build it first.
+    * @returns The SQL string of the union query.
+    * @throws Error if the query fails to build.
+    */
+  public toSQL(): string {
+    if(!this.builtQuery) this.build();
+    if(!this.builtQuery) throw new Error("Failed to build the query.");
+    return this.builtQuery;
+    
+  }
+
+  /**
+    * Retrieves the parameter values for the union query.
+    * If the query has not been built yet, it will build it first.
+    * @returns An array of parameter values for the union query.
+    * @throws Error if the query fails to build.
+    */
+  public getParams(): any[] {
+    if(!this.builtParams) this.build();
+    if(!this.builtParams) throw new Error("Failed to build the query.");
+    return this.builtParams;
+  }
+
+  /**
+    * Creates a deep clone of the current Union instance.
+    * This includes cloning all properties and nested objects to ensure
+    * that modifications to the clone do not affect the original instance.
+    * @returns A new Union instance that is a deep clone of the current instance.
+    */
+  public clone(): Union {
+    const newUnion = new Union();
+    newUnion.unionAlias = this.unionAlias;
+    newUnion.limitCount = this.limitCount;
+    newUnion.offsetCount = this.offsetCount;
+    newUnion.schemas = [...this.schemas];
+    newUnion.selectQueries = this.selectQueries.map(sq => ({
+      query: sq.query.clone() as SelectQuery,
+      type: sq.type
+    }));
+    newUnion.orderBys = [...this.orderBys];
+    newUnion.groupBys = [...this.groupBys];
+    newUnion.havingStatement = this.havingStatement ? this.havingStatement.clone() : null;
+    newUnion.whereStatement = this.whereStatement ? this.whereStatement.clone() : null;
+    return newUnion;
+  }
+
+  /**
+    * Resets the internal state of the Union instance.
+    * This clears all properties, including the union alias, limit, offset,
+    * select queries, order by clauses, group by clauses, having statement,
+    * where statement, built query, built parameters, and schemas.
+    * After calling this method, the Union instance will be in its initial state.
+    */
+  public reset(): void {
+    this.unionAlias = null;
+    this.limitCount = null;
+    this.offsetCount = null;
+    this.selectQueries = [];
+    this.orderBys = [];
+    this.groupBys = [];
+    this.havingStatement = null;
+    this.whereStatement = null;
+    this.builtQuery = null;
+    this.builtParams = null;
+    this.schemas = [];
+  }
+
+  /**
+    * This is a UNION query.
+    * @returns The kind of SQL operation, which is 'UNION' for this class.
+    */
+  public get kind() {
+    return QueryKind.UNION;
+  }
+
+}
+

--- a/src/queryKinds/update.test.ts
+++ b/src/queryKinds/update.test.ts
@@ -38,6 +38,30 @@ describe('Update Query', () => {
     expect(query3.values).toEqual(['Jane', 25, 2]);
   });
 
+  it('should support useStatement', () => {
+    const query = new UpdateQuery('users', 'u')
+      .set({
+        setColumn: 'name', value: 'Jane'
+      })
+      .useStatement(stmt => stmt.and('age = ?', 25))
+      .build();
+
+    expect(query.text).toBe('UPDATE "users" u\nSET "name" = $1\nWHERE (age = $2)');
+    expect(query.values).toEqual(['Jane', 25]);
+
+    const query2 = new UpdateQuery('users', 'u')
+      .set({
+        setColumn: 'name', value: 'Jane'
+      })
+      .useStatement(stmt => {
+        stmt.and('age = ?', 25);
+      })
+      .build();
+
+    expect(query2.text).toBe('UPDATE "users" u\nSET "name" = $1\nWHERE (age = $2)');
+    expect(query2.values).toEqual(['Jane', 25]);
+  });
+
   it('should generate UPDATE SQL with RETURNING clause', () => {
     const query = new UpdateQuery('users')
       .set({ name: 'Alice', age: 28 })

--- a/src/queryKinds/update.test.ts
+++ b/src/queryKinds/update.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import UpdateQuery from "./update.js";
+import Statement from "../statementMaker.js";
+import { Cte } from "../cteMaker.js";
+import SelectQuery from "./select.js";
+
+describe('Update Query', () => {
+  it('should generate correct UPDATE SQL', () => {
+    const query = new UpdateQuery()
+      .from('users', 'u')
+      .set({ name: 'John', age: 30 })
+      .where('u.id = ?', 1)
+      .build();
+
+    expect(query.text).toBe('UPDATE "users" u\nSET "name" = $1, "age" = $2\nWHERE (u.id = $3)');
+    expect(query.values).toEqual(['John', 30, 1]);
+
+    const query2 = new UpdateQuery('users')
+      .set([
+        { setColumn: 'name', value: 'Jane' },
+        { setColumn: 'age', value: 25 }
+      ])
+      .where('id = ?', 2)
+      .build();
+
+    expect(query2.text).toBe('UPDATE "users"\nSET "name" = $1, "age" = $2\nWHERE (id = $3)');
+    expect(query2.values).toEqual(['Jane', 25, 2]);
+
+    const query3 = new UpdateQuery('users', 'u')
+      .set({
+        setColumn: 'name', value: 'Jane'
+      })
+      .addSetValue('age', 25)
+      .where('u.id = ?', 2)
+      .build();
+
+    expect(query3.text).toBe('UPDATE "users" u\nSET "name" = $1, "age" = $2\nWHERE (u.id = $3)');
+    expect(query3.values).toEqual(['Jane', 25, 2]);
+  });
+
+  it('should generate UPDATE SQL with RETURNING clause', () => {
+    const query = new UpdateQuery('users')
+      .set({ name: 'Alice', age: 28 })
+      .returning(['id', 'name'])
+      .returning('id')
+      .addReturning('name')
+      .addReturning(['age'])
+      .where('id = ?', 3)
+      .build();
+
+    expect(query.text).toBe('UPDATE "users"\nSET "name" = $1, "age" = $2\nWHERE (id = $3)\nRETURNING "id", "name", "age"');
+    expect(query.values).toEqual(['Alice', 28, 3]);
+  });
+
+  it('should error when no set values provided', () => {
+    expect(() => {
+      new UpdateQuery('users').where('id = ?', 1).build();
+    }).toThrow('No SET values specified for UPDATE query.');
+  });
+
+  it('should support using other table', () => {
+    const query = new UpdateQuery('users', 'u')
+      .using('teams', 't')
+      .set({ 'u.status': 'inactive' })
+      .where(
+        new Statement()
+          .and('u.team_id = t.id')
+          .and('t.active = ?', [false])
+      )
+      .build();
+
+    expect(query.text).toBe('UPDATE "users" u\nSET "u"."status" = $1\nFROM "teams" t\nWHERE (u.team_id = t.id)\n AND (t.active = $2)');
+    expect(query.values).toEqual(['inactive', false]);
+  });
+
+  it('should support joining other tables while using other table', () => {
+    const query = new UpdateQuery('users', 'u')
+      .using('teams', 't')
+      .join({
+        table: 'departments',
+        alias: 'd',
+        type: 'INNER',
+        on: 't.department_id = d.id'
+      })
+      .set({ 'u.status': 'inactive' })
+      .where(
+        new Statement()
+          .and('u.team_id = t.id')
+          .and('d.active = ?', [false])
+      )
+      .build();
+
+    expect(query.text).toBe('UPDATE "users" u\nSET "u"."status" = $1\nFROM "teams" t\nINNER JOIN "departments" d\n ON t.department_id = d.id\nWHERE (u.team_id = t.id)\n AND (d.active = $2)');
+    expect(query.values).toEqual(['inactive', false]);
+  });
+
+  it('should throw error if no table is specified', () => {
+    expect(() => {
+      new UpdateQuery().set({ name: 'John' }).build();
+    }).toThrow('No table specified for UPDATE query.');
+  });
+
+  it('should support joining multiple tables', () => {
+    // Cannot use conditios for joins using table being updated
+    const query = new UpdateQuery('orders', 'o')
+      .join([
+        {
+          table: 'customers',
+          alias: 'c',
+          type: 'LEFT',
+          on: 'r.id = c.region_id'
+        },
+        {
+          table: 'products',
+          alias: 'p',
+          type: 'INNER',
+          on: 'r.id = p.region_id'
+        }
+      ])
+      .using('regions', 'r')
+      .set({ 'o.status': 'shipped' })
+      .addSet('o.date_shipped', 'NOW()')
+      .where(
+        new Statement()
+          .and('o.region_id = r.id')
+          .and('r.name = ?', ['North'])
+          .and('p.stock > ?', [0])
+      )
+      .build();
+
+    expect(query.text).toBe('UPDATE "orders" o\nSET "o"."status" = $1, "o"."date_shipped" = "NOW()"\nFROM "regions" r\nLEFT JOIN "customers" c\n ON r.id = c.region_id\nINNER JOIN "products" p\n ON r.id = p.region_id\nWHERE (o.region_id = r.id)\n AND (r.name = $2)\n AND (p.stock > $3)');
+    expect(query.values).toEqual(['shipped', 'North', 0]);
+  });
+
+  it('should return its kind', () => {
+    const query = new UpdateQuery('users');
+    expect(query.kind).toBe('UPDATE');
+  });
+
+  it('should reset its state', () => {
+    const query = new UpdateQuery('users')
+      .set({ name: 'John', age: 30 })
+      .returning(['id', 'name']);
+
+    const built = query.build();
+    expect(built.text).toBe('UPDATE "users"\nSET "name" = $1, "age" = $2\nRETURNING "id", "name"');
+    expect(built.values).toEqual(['John', 30]);
+
+    query.reset();
+
+    expect(() => {
+      query.build();
+    }).toThrow('No table specified for UPDATE query.');
+  });
+
+  it('should invalidate its built query', () => {
+    const query = new UpdateQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .set({ name: 'John' })
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    const firstBuild = query.build();
+    expect(firstBuild.text).toBe('UPDATE "users" u\nSET "name" = $1\nWHERE (u.id = $2)\nRETURNING "id", "email", "biscuit"');
+    expect(firstBuild.values).toEqual(['John', 1]);
+    expect(query.isDone).toBe(true);
+
+    query.set({ age: 25 });
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('UPDATE "users" u\nSET "age" = $1\nWHERE (u.id = $2)\nRETURNING "id", "email", "biscuit"');
+    expect(secondBuild.values).toEqual([25, 1]);
+  });
+
+  it('should be able to get query definition', () => {
+    const query = new UpdateQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .set({ name: 'John' })
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    expect(query.query).toEqual(query);
+  });
+
+  it('should be able to get params and sql directly', () => {
+    const query = new UpdateQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .set({ name: 'John' })
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    expect(query.toSQL()).toBe('UPDATE "users" u\nSET "name" = $1\nWHERE (u.id = $2)\nRETURNING "id", "email", "biscuit"');
+    query.invalidate();
+    expect(query.getParams()).toEqual(['John', 1]);
+
+    expect(query.toSQL()).toBe('UPDATE "users" u\nSET "name" = $1\nWHERE (u.id = $2)\nRETURNING "id", "email", "biscuit"');
+    expect(query.getParams()).toEqual(['John', 1]);
+  });
+
+  it('should be able to clone itself', () => {
+    const query = new UpdateQuery('users', 'u')
+      .where('u.id = ?', 1)
+      .set({ name: 'John' })
+      .returning(['id', 'email'])
+      .addReturning('biscuit');
+
+    const clone = query.clone();
+    expect(clone).not.toBe(query);
+    expect(clone.build()).toEqual(query.build());
+
+    clone.set({ name: 'Jane' });
+    clone.invalidate();
+
+    expect(clone.build().values).toEqual(['Jane', 1]);
+    expect(query.build().values).toEqual(['John', 1]);
+  });
+
+  it('should be able to use statements on conditions for joins', () => {
+    const query = new UpdateQuery('orders', 'o')
+      .using('customers', 'c')
+      .join({
+        table: 'regions',
+        alias: 'r',
+        type: 'INNER',
+        on: new Statement().and('o.customer_id = c.id').and('c.active = ?', true)
+      })
+      .set({ 'o.status': 'shipped' })
+      .where(
+        new Statement()
+          .and('o.id = ?', 1)
+          .and('o.region_id = r.id')
+      )
+      .build();
+
+    expect(query.text).toBe('UPDATE "orders" o\nSET "o"."status" = $1\nFROM "customers" c\nINNER JOIN "regions" r\n ON (o.customer_id = c.id) AND (c.active = $2)\nWHERE (o.id = $3)\n AND (o.region_id = r.id)');
+    expect(query.values).toEqual(['shipped', true, 1]);
+  });
+
+  it('should support CTEs', () => {
+    const query = new UpdateQuery('users', 'u')
+      .with(
+        new Cte(
+          'active_teams',
+          new SelectQuery('teams')
+            .where('active = ?', true)
+            .select(['id', 'name']),
+          false
+        )
+      )
+      .using('active_teams', 'at')
+      .set({ 'u.status': 'inactive' })
+      .where('u.team_id = at.id')
+      .build();
+
+    expect(query.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\nUPDATE "users" u\nSET "u"."status" = $2\nFROM "active_teams" at\nWHERE (u.team_id = at.id)');
+    expect(query.values).toEqual([true, 'inactive']);
+  });
+
+  it('should support invalidating with CTEs', () => {
+    const query = new UpdateQuery('users', 'u')
+      .with(
+        new Cte(
+          'active_teams',
+          new SelectQuery('teams')
+            .where('active = ?', true)
+            .select(['id', 'name']),
+          false
+        )
+      )
+      .using('active_teams', 'at')
+      .set({ 'u.status': 'inactive' })
+      .where('u.team_id = at.id');
+
+    const firstBuild = query.build();
+    expect(query.isDone).toBe(true);
+
+    expect(firstBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\nUPDATE "users" u\nSET "u"."status" = $2\nFROM "active_teams" at\nWHERE (u.team_id = at.id)');
+    expect(firstBuild.values).toEqual([true, 'inactive']);
+
+    query.with(
+      new Cte(
+        'active_teams',
+        new SelectQuery('teams')
+          .where('active = ?', false)
+          .select(['id', 'name']),
+        false
+      )
+    );
+    query.invalidate();
+    expect(query.isDone).toBe(false);
+
+    const secondBuild = query.build();
+    expect(secondBuild.text).toBe('WITH active_teams AS (\nSELECT\n "id",\n "name"\nFROM "teams"\nWHERE (active = $1)\n)\nUPDATE "users" u\nSET "u"."status" = $2\nFROM "active_teams" at\nWHERE (u.team_id = at.id)');
+    expect(secondBuild.values).toEqual([false, 'inactive']);
+  });
+
+});

--- a/src/queryKinds/update.ts
+++ b/src/queryKinds/update.ts
@@ -2,6 +2,7 @@ import CteMaker, { Cte } from "../cteMaker.js";
 import SqlEscaper from "../sqlEscaper.js";
 import Statement from "../statementMaker.js";
 import Join from "../types/Join.js";
+import QueryKind from "../types/QueryKind.js";
 import SetValue from "../types/SetValue.js";
 import QueryDefinition from "./query.js";
 
@@ -25,14 +26,8 @@ export default class UpdateQuery extends QueryDefinition {
   private joins: Join[] = [];
   /** SET values for the update. */
   private setValues: SetValue[] = [];
-  /** WHERE clause statement. */
-  private whereStatement: Statement | null = null;
   /** RETURNING fields. */
   private returningFields: string[] = [];
-  /** The final built SQL query string. */
-  private builtQuery: string | null = null;
-  /** Optional Common Table Expressions (CTEs) for the query. */
-  private ctes: CteMaker | null = null;
 
   /**
     * Creates an instance of UpdateQuery.
@@ -41,7 +36,7 @@ export default class UpdateQuery extends QueryDefinition {
     */
   constructor(table?: string, alias?: string) {
     super();
-    this.table = SqlEscaper.escapeTableName(table || '', this.flavor);
+    this.table = table ? SqlEscaper.escapeTableName(table, this.flavor) : '';
     this.tableAlias = alias || null;
   }
 
@@ -113,7 +108,7 @@ export default class UpdateQuery extends QueryDefinition {
     * @param values - The SET value(s) to be added.
     * @returns The current UpdateQuery instance for method chaining.
     */
-  public set(values: SetValue | SetValue[]): this {
+  public set(values: SetValue | SetValue[] | { [key: string]: any }): this {
     if (Array.isArray(values)) {
       this.setValues = values
         .filter(v => v.value !== undefined)
@@ -122,12 +117,17 @@ export default class UpdateQuery extends QueryDefinition {
           from: v.from ? SqlEscaper.escapeTableName(v.from, this.flavor) : undefined as any,
           value: v.value ?? null 
         }));
-    } else if (values.value !== undefined) {
+    } else if (values?.setColumn && (values?.from || values?.value !== undefined)) {
       this.setValues = [{
         setColumn: values.setColumn ? SqlEscaper.escapeTableName(values.setColumn, this.flavor) : '',
         from: values.from ? SqlEscaper.escapeTableName(values.from, this.flavor) : undefined as any,
         value: values.value ?? null
       }];
+    } else if (typeof values === 'object' && !Array.isArray(values)) {
+      this.setValues = Object.entries(values).map(([key, val]) => ({
+        setColumn: SqlEscaper.escapeTableName(key, this.flavor),
+        value: val
+      }));
     }
     return this;
   }
@@ -198,9 +198,24 @@ export default class UpdateQuery extends QueryDefinition {
     */
   public returning(fields: string | string[]): this {
     if (Array.isArray(fields)) {
-      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers(fields, this.flavor));
+      this.returningFields = SqlEscaper.escapeSelectIdentifiers(fields, this.flavor);
     } else {
-      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers([fields], this.flavor));
+      this.returningFields = SqlEscaper.escapeSelectIdentifiers([fields], this.flavor);
+    }
+    return this;
+  }
+
+  /**
+    * Adds additional RETURNING fields to the update.
+    * Accepts either a single field name or an array of field names.
+    * @param field - The field(s) to be added to the RETURNING clause.
+    * @returns The current UpdateQuery instance for method chaining.
+    */
+  public addReturning(field: string | string[]): this {
+    if (Array.isArray(field)) {
+      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers(field, this.flavor));
+    } else {
+      this.returningFields.push(...SqlEscaper.escapeSelectIdentifiers([field], this.flavor));
     }
     return this;
   }
@@ -223,6 +238,7 @@ export default class UpdateQuery extends QueryDefinition {
     }
 
     this.whereStatement = this.whereStatement || new Statement();
+    this.whereStatement?.setOffset(1);
 
     let ctesClause = '';
     let cteValues: any[] = [];
@@ -270,13 +286,13 @@ export default class UpdateQuery extends QueryDefinition {
     }
 
     let joinClauses = '';
-    let currentOffset = 0;
+    let currentOffset = setValues.length;
     let parametersToAdd: any = [];
     for (const join of this.joins) {
       const onClause = 
         typeof join.on === 'string' ? join.on
         : (() => {
-            join.on.enableWhere();
+            join.on.disableWhere();
             join.on.addOffset(currentOffset);
             const stmt = join.on.build(false);
             currentOffset += stmt.values.length;
@@ -315,9 +331,11 @@ export default class UpdateQuery extends QueryDefinition {
     );
 
     const allValues = [...cteValues, ...setValues, ...values];
+
     const analyzed = this.reAnalyzeParsedQueryForDuplicateParams(this.builtQuery, allValues, deepAnalysis);
     this.builtQuery = analyzed.text;
-    return { text: this.builtQuery, values: analyzed.values };
+    this.builtParams = analyzed.values;
+    return { text: this.builtQuery, values: this.builtParams };
   }
 
   /**
@@ -326,47 +344,17 @@ export default class UpdateQuery extends QueryDefinition {
     * @returns The SQL query string.
     */
   public toSQL(): string {
-    return this.build().text;
-  }
-
-  /**
-    * Indicates whether the query has been built.
-    * Returns true if the builtQuery property is not null.
-    * @returns A boolean indicating if the query is built.
-    */
-  public get isDone(): boolean {
-    return this.builtQuery !== null;
+    if (!this.builtQuery) this.build();
+    if (!this.builtQuery) throw new Error('Failed to build the SQL query.');
+    return this.builtQuery;
   }
 
   /**
     * This an UPDATE query.
     * @returns The string 'UPDATE'.
     */
-  public get kind(): 'INSERT' | 'UPDATE' | 'DELETE' | 'SELECT' {
-    return 'UPDATE';
-  }
-
-  /**
-    * Provides access to the current query definition instance.
-    * @returns The current UpdateQuery instance.
-    */
-  public get query(): QueryDefinition {
-    return this;
-  }
-
-  /**
-    * Invalidates the current state of the query definition, forcing a rebuild on the next operation.
-    * It also invalidates any associated WHERE statements and CTE queries.
-    * @returns void
-    */
-  public invalidate(): void {
-    this.builtQuery = null;
-    if (this.whereStatement) this.whereStatement.invalidate();
-    if (this.ctes) {
-      for (const cte of this.ctes['ctes']) {
-        cte['query'].invalidate();
-      }
-    }
+  public get kind() {
+    return QueryKind.UPDATE;
   }
 
   /**
@@ -385,6 +373,7 @@ export default class UpdateQuery extends QueryDefinition {
     this.returningFields = [];
     this.builtQuery = null;
     this.ctes = null;
+    this.schemas = [];
   }
 
   /**
@@ -393,7 +382,9 @@ export default class UpdateQuery extends QueryDefinition {
     * @returns An array of parameters for the query.
     */
   public getParams(): any[] {
-    return this.build().values;
+    if (!this.builtParams) this.build();
+    if (!this.builtParams) throw new Error('Failed to build the SQL query.');
+    return this.builtParams;
   }
 
   /**
@@ -402,7 +393,11 @@ export default class UpdateQuery extends QueryDefinition {
     * @returns A new UpdateQuery instance that is a clone of the current instance.
     */
   public clone(): UpdateQuery {
-    const cloned = new UpdateQuery(this.table, this.tableAlias || undefined);
+    const cloned = new UpdateQuery();
+    cloned.table = this.table;
+    cloned.tableAlias = this.tableAlias;
+    cloned.flavor = this.flavor;
+    cloned.schemas = [...this.schemas];
     cloned.usingTable = this.usingTable;
     cloned.usingAlias = this.usingAlias;
     cloned.joins = JSON.parse(JSON.stringify(this.joins));

--- a/src/queryMaker.test.ts
+++ b/src/queryMaker.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import Query from "./queryMaker.js";
+
+
+describe('Query Class', () => {
+  it('should create simple select queries', () => {
+    const selectQuery = Query.select
+      .from('users', 'u')
+      .select(['u.id', 'u.name'])
+      .where('u.active = ?', true)
+      .orderBy({ field: 'u.name', direction: 'ASC' })
+      .limit(10)
+      .offset(5)
+      .build();
+
+    expect(selectQuery.text).toBe('SELECT\n "u"."id",\n "u"."name"\nFROM "users" AS u\nWHERE (u.active = $1)\nORDER BY "u"."name" ASC\nLIMIT 10 OFFSET 5');
+    expect(selectQuery.values).toEqual([true]);
+
+    const insertQuery = Query.create
+      .into('users')
+      .values({ name: 'John', age: 30 })
+      .returning(['id', 'name'])
+      .build();
+
+    expect(insertQuery.text).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2)\nRETURNING "id", "name"');
+    expect(insertQuery.values).toEqual(['John', 30]);
+
+    const updateQuery = Query.update
+      .from('users')
+      .set({ name: 'Jane' })
+      .where('id = ?', 1)
+      .returning('id')
+      .build();
+
+    expect(updateQuery.text).toBe('UPDATE "users"\nSET "name" = $1\nWHERE (id = $2)\nRETURNING "id"');
+    expect(updateQuery.values).toEqual(['Jane', 1]);
+
+    const deleteQuery = Query.delete.from('users', 'u')
+      .where('u.id = ?', 1)
+      .build();
+
+    expect(deleteQuery.text).toBe('DELETE FROM "users" AS u\n WHERE (u.id = $1)');
+    expect(deleteQuery.values).toEqual([1]);
+
+    const cteQuery = Query.cte
+      .withQuery(Query.select.from('users').select('*'))
+      .as('all_users')
+      .build();
+
+    expect(cteQuery.text).toBe('all_users AS (\nSELECT\n "*"\nFROM "users"\n)');
+    expect(cteQuery.values).toEqual([]);
+
+
+    const selectQuery2 = Query.select
+      .from('orders', 'o')
+      .select(['o.id', 'o.total'])
+      .where('o.completed = ?', true)
+      .orderBy({ field: 'o.created_at', direction: 'DESC' })
+      .limit(15)
+      .offset(0);
+
+    const selectQuery3 = Query.select
+      .from('customers', 'c')
+      .select(['c.id', 'c.name'])
+      .where('c.active = ?', true)
+      .orderBy({ field: 'c.name', direction: 'ASC' })
+      .limit(10)
+      .offset(0);
+
+    const unionQuery = Query.union
+      .add(selectQuery2)
+      .add(selectQuery3, 'union all')
+      .orderBy({ field: 'id', direction: 'ASC' })
+      .as('union_subquery')
+      .limit(30)
+      .offset(0)
+      .build();
+
+    expect(unionQuery.text).toBe('SELECT * FROM (\n (SELECT\n  "o"."id",\n  "o"."total"\n FROM "orders" AS o\n WHERE (o.completed = $1)\n ORDER BY "o"."created_at" DESC\n LIMIT 15 OFFSET 0)\n\n UNION ALL\n\n (SELECT\n  "c"."id",\n  "c"."name"\n FROM "customers" AS c\n WHERE (c.active = $1)\n ORDER BY "c"."name" ASC\n LIMIT 10 OFFSET 0)\n) AS union_subquery\nORDER BY "id" ASC\nLIMIT 30\nOFFSET 0');
+    expect(unionQuery.values).toEqual([true]);
+  });
+
+  it('should be constructable', () => {
+    const query = new Query();
+
+    const selectQuery = query.select
+      .from('products', 'p')
+      .select(['p.id', 'p.name'])
+      .where('p.in_stock = ?', true)
+      .orderBy({ field: 'p.name', direction: 'DESC' })
+      .limit(20)
+      .offset(0);
+
+    const builtQuery = selectQuery.build();
+
+    expect(builtQuery.text).toBe('SELECT\n "p"."id",\n "p"."name"\nFROM "products" AS p\nWHERE (p.in_stock = $1)\nORDER BY "p"."name" DESC\nLIMIT 20 OFFSET 0');
+    expect(builtQuery.values).toEqual([true]);
+
+    const insertQuery = query.create
+      .into('products')
+      .values({ name: 'Laptop', price: 999.99 })
+      .returning(['id', 'name']);
+
+    const builtInsert = insertQuery.build();
+
+    expect(builtInsert.text).toBe('INSERT INTO "products" ("name", "price") VALUES ($1, $2)\nRETURNING "id", "name"');
+    expect(builtInsert.values).toEqual(['Laptop', 999.99]);
+
+    const updateQuery = query.update
+      .from('products')
+      .set({ price: 899.99 })
+      .where('id = ?', 1)
+      .returning('id');
+
+    const builtUpdate = updateQuery.build();
+
+    expect(builtUpdate.text).toBe('UPDATE "products"\nSET "price" = $1\nWHERE (id = $2)\nRETURNING "id"');
+    expect(builtUpdate.values).toEqual([899.99, 1]);
+
+    const deleteQuery = query.delete.from('products', 'p')
+      .where('p.id = ?', 1);
+
+    const builtDelete = deleteQuery.build();
+
+    expect(builtDelete.text).toBe('DELETE FROM "products" AS p\n WHERE (p.id = $1)');
+    expect(builtDelete.values).toEqual([1]);
+
+    const cteQuery = query.cte
+      .withQuery(query.select.from('products').select('*'))
+      .as('all_products');
+
+    const builtCte = cteQuery.build();
+
+    expect(builtCte.text).toBe('all_products AS (\nSELECT\n "*"\nFROM "products"\n)');
+    expect(builtCte.values).toEqual([]);
+
+    const selectQuery2 = query.select
+      .from('orders', 'o')
+      .select(['o.id', 'o.total'])
+      .where('o.completed = ?', true)
+      .orderBy({ field: 'o.created_at', direction: 'DESC' })
+      .limit(15)
+      .offset(0);
+
+    const selectQuery3 = query.select
+      .from('customers', 'c')
+      .select(['c.id', 'c.name'])
+      .where('c.active = ?', true)
+      .orderBy({ field: 'c.name', direction: 'ASC' })
+      .limit(10)
+      .offset(0);
+
+    const unionQuery = query.union
+      .add(selectQuery2)
+      .add(selectQuery3, 'union all')
+      .orderBy({ field: 'id', direction: 'ASC' })
+      .as('union_subquery')
+      .limit(30)
+      .offset(0);
+
+    const builtUnion = unionQuery.build();
+
+    expect(builtUnion.text).toBe('SELECT * FROM (\n (SELECT\n  "o"."id",\n  "o"."total"\n FROM "orders" AS o\n WHERE (o.completed = $1)\n ORDER BY "o"."created_at" DESC\n LIMIT 15 OFFSET 0)\n\n UNION ALL\n\n (SELECT\n  "c"."id",\n  "c"."name"\n FROM "customers" AS c\n WHERE (c.active = $1)\n ORDER BY "c"."name" ASC\n LIMIT 10 OFFSET 0)\n) AS union_subquery\nORDER BY "id" ASC\nLIMIT 30\nOFFSET 0');
+    expect(builtUnion.values).toEqual([true]);
+  });
+});

--- a/src/queryMaker.ts
+++ b/src/queryMaker.ts
@@ -2,6 +2,7 @@ import { Cte } from "./cteMaker.js";
 import DeleteQuery from "./queryKinds/delete.js";
 import InsertQuery from "./queryKinds/insert.js";
 import SelectQuery from "./queryKinds/select.js";
+import Union from "./queryKinds/union.js";
 import UpdateQuery from "./queryKinds/update.js";
 import Statement from "./statementMaker.js";
 import sqlFlavor from "./types/sqlFlavor.js";
@@ -85,6 +86,15 @@ class Query {
     return new Cte();
   }
 
+  public get union(): Union {
+    const unionQuery = new Union();
+    (unionQuery as any).flavor = this.flavor;
+    unionQuery.build = (deepAnalysis: boolean = this.deepAnalysisDefault) => {
+      return Union.prototype.build.call(unionQuery, deepAnalysis);
+    }
+    return unionQuery;
+  }
+
   /**
     * Initiates a new SELECT query.
     * @returns A new SelectQuery instance.
@@ -133,6 +143,10 @@ class Query {
     */
   public static get cte(): Cte {
     return new Cte();
+  }
+
+  public static get union(): Union {
+    return new Union();
   }
 
 }

--- a/src/signal.test.ts
+++ b/src/signal.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import Signal from './signal.js';
+
+
+describe('Synchronous Signals', () => {
+  
+  it('should handle basic signal operations', () => {
+    let value = 0;
+    const signal = new Signal<number>(0);
+    signal.subscribe((val) => {
+      value = val;
+    });
+
+    expect(signal.value).toBe(0);
+    expect(value).toBe(0);
+
+    signal.value = 5;
+    expect(signal.value).toBe(5);
+    expect(value).toBe(5);
+
+    signal.value = 10;
+    expect(signal.value).toBe(10);
+    expect(value).toBe(10);
+  });
+
+  it('should handle multiple subscribers', () => {
+    let value1 = 0;
+    let value2 = 0;
+    const signal = new Signal<number>(0);
+    
+    signal.subscribe((val) => {
+      value1 = val;
+    });
+
+    signal.subscribe((val) => {
+      value2 = val;
+    });
+
+    expect(signal.value).toBe(0);
+    expect(value1).toBe(0);
+    expect(value2).toBe(0);
+
+    signal.value = 7;
+    expect(signal.value).toBe(7);
+    expect(value1).toBe(7);
+    expect(value2).toBe(7);
+  });
+
+  it('should allow unsubscribing', () => {
+    let value = 0;
+    const signal = new Signal<number>(0);
+    
+    const unsubscribe = signal.subscribe((val) => {
+      value = val;
+    });
+
+    expect(signal.value).toBe(0);
+    expect(value).toBe(0);
+
+    signal.value = 3;
+    expect(signal.value).toBe(3);
+    expect(value).toBe(3);
+
+    unsubscribe();
+
+    signal.value = 8;
+    expect(signal.value).toBe(8);
+    expect(value).toBe(3); // value should not change after unsubscribe
+  });
+
+  it('should handle complex types', () => {
+    let objValue: { a: number; b: string } = { a: 0, b: '' };
+    const signal = new Signal<{ a: number; b: string }>({ a: 0, b: '' });
+    
+    signal.subscribe((val) => {
+      objValue = val;
+    });
+
+    expect(signal.value).toEqual({ a: 0, b: '' });
+    expect(objValue).toEqual({ a: 0, b: '' });
+
+    signal.value = { a: 1, b: 'test' };
+    expect(signal.value).toEqual({ a: 1, b: 'test' });
+    expect(objValue).toEqual({ a: 1, b: 'test' });
+  });
+
+  it('should support subscribing once', () => {
+    let callCount = 0;
+    const signal = new Signal<number>(0);
+    
+    signal.subscribeOnce(() => {
+      callCount++;
+    });
+
+    expect(callCount).toBe(0);
+
+    signal.value = 1;
+    expect(callCount).toBe(1);
+
+    signal.value = 2;
+    expect(callCount).toBe(1); // callCount should not increase after the first call
+  });
+
+  it('should handle nested signals', () => {
+    let innerValue = 0;
+    const innerSignal = new Signal<number>(0);
+    const outerSignal = new Signal<Signal<number>>(innerSignal);
+    
+    outerSignal.value.subscribe((val) => {
+      innerValue = val;
+    });
+
+    expect(innerValue).toBe(0);
+
+    innerSignal.value = 4;
+    expect(innerValue).toBe(4);
+
+    const newInnerSignal = new Signal<number>(10, true);
+
+    newInnerSignal.subscribe((val) => {
+      innerValue = val;
+    });
+
+    outerSignal.value = newInnerSignal;
+    expect(innerValue).toBe(10);
+
+    newInnerSignal.value = 20;
+    expect(innerValue).toBe(20);
+  });
+
+  it('should handle immediate flag', () => {
+    let value = 0;
+    const signal = new Signal<number>(6, true);
+    
+    signal.subscribe((val) => {
+      value = val;
+    });
+
+    expect(value).toBe(6);
+
+    signal.value = 3;
+    expect(value).toBe(3);
+  });
+
+  it('should notify subscribers even if value is unchanged', () => {
+    let callCount = 0;
+    const signal = new Signal<number>(5);
+    
+    signal.subscribe(() => {
+      callCount++;
+    });
+
+    expect(callCount).toBe(0);
+
+    signal.value = 5; // same value
+    expect(callCount).toBe(1); // should notify
+
+    signal.value = 10; // different value
+    expect(callCount).toBe(2); // should also notify
+  });
+
+  it('should handle destroying itself', () => {
+    let value = 0;
+    const signal = new Signal<number>(0);
+    
+    signal.subscribe((val) => {
+      value = val;
+    });
+
+    expect(signal.value).toBe(0);
+    expect(value).toBe(0);
+
+    signal.value = 9;
+    expect(signal.value).toBe(9);
+    expect(value).toBe(9);
+
+    signal.destroy();
+
+    signal.value = 15;
+    expect(signal.value).toBe(15);
+    expect(value).toBe(9); // value should not change after destroy
+  });
+
+  it('should support unsubscribing all subscribers', () => {
+    let value1 = 0;
+    let value2 = 0;
+    const signal = new Signal<number>(0);
+    
+    signal.subscribe((val) => {
+      value1 = val;
+    });
+
+    signal.subscribe((val) => {
+      value2 = val;
+    });
+
+    expect(signal.value).toBe(0);
+    expect(value1).toBe(0);
+    expect(value2).toBe(0);
+
+    signal.value = 11;
+    expect(signal.value).toBe(11);
+    expect(value1).toBe(11);
+    expect(value2).toBe(11);
+
+    signal.clearSubscribers();
+
+    signal.value = 20;
+    expect(signal.value).toBe(20);
+    expect(value1).toBe(11); // value1 should not change after unsubscribeAll
+    expect(value2).toBe(11); // value2 should not change after unsubscribeAll
+  });
+
+  it('should support unsubscribing once subscribers', () => {
+    let callCount = 0;
+    const signal = new Signal<number>(1, true);
+    
+    const unsubscribe = signal.subscribeOnce(() => {
+      callCount++;
+    });
+
+    expect(callCount).toBe(1);
+
+    unsubscribe();
+
+    signal.value = 1;
+    expect(callCount).toBe(1); // callCount should not increase after unsubscribe
+  });
+
+});

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,0 +1,151 @@
+
+/**
+  * Callback function type for subscribers.
+  * It can return void or a Promise<void>.
+  */
+export type callbackFn<T> = (value: T) => any | Promise<any>;
+
+/**
+  * Signal class to manage a value and notify subscribers on changes.
+  * It supports subscribing, subscribing once, and clearing subscribers.
+  */
+export default class Signal<T = null> {
+
+  /**
+    * If true, subscribers are notified immediately upon subscription.
+    * Useful for late subscribers to get the current value right away.
+    */
+  public immediate: boolean;
+
+  /**
+    * List of subscriber callback functions.
+    */
+  private subscribers: callbackFn<T>[] = [];
+
+  /**
+    * The current value of the signal.
+    */
+  private _value: T | null = null;
+
+  /**
+    * Creates a new Signal instance with an initial value.
+    * @param initialValue - The initial value of the signal.
+    */
+  constructor(
+    initialValue: T | null = null,
+    immediate: boolean = false
+  ) {
+    this._value = initialValue;
+    this.immediate = immediate;
+  }
+
+  /**
+    * Creates a new Signal instance with an initial value.
+    * @param initialValue - The initial value of the signal.
+    * @returns A new Signal instance.
+    */
+  public static create<U>(
+    initialValue: U | null = null,
+    immediate: boolean = false
+  ): Signal<U> {
+    return new Signal<U>(
+      initialValue,
+      immediate
+    );
+  }
+
+  /**
+    * Destroys the signal by clearing subscribers and setting the value to null.
+    */
+  public destroy() {
+    this.clearSubscribers();
+    this._value = null;
+  }
+
+  /**
+    * The current value of the signal.
+    */
+  public get value(): T {
+    return this._value as T;
+  }
+
+  public set value(newValue: T) {
+    this._value = newValue;
+    this.notifySubscribers(newValue);
+  }
+
+  /**
+    * Sets the value of the signal using a callback function.
+    * The callback receives the current value and should return the new value.
+    * @param callback - The callback function to compute the new value.
+    */
+  public setValue(callback: (currentValue: T) => any) {
+    callback(this._value!);
+    this.notifySubscribers(this._value as T);
+  }
+
+  /**
+    * Subscribes to changes in the signal's value.
+    * @param callback - The callback function(s) to be called when the value changes.
+    * @returns A function to unsubscribe the provided callbacks.
+    */
+  public subscribe(...callback: callbackFn<T>[]) {
+    this.subscribers.push(...callback);
+
+    if (this.immediate && this._value !== null) {
+      for (const cb of callback) {
+        void cb(this._value);
+      }
+    }
+
+    // Return an unsubscribe function
+    return () => {
+      this.subscribers = this.subscribers.filter(sub => !callback.includes(sub));
+    };
+  }
+
+  /**
+    * Subscribes to the signal's value changes only once.
+    * The callback will be called the next time the value changes and then unsubscribed.
+    * @param callback - The callback function(s) to be called when the value changes.
+    * @returns A function to unsubscribe the provided callbacks if they haven't been called yet.
+    */
+  public subscribeOnce(...callback: callbackFn<T>[]) {
+    const onceCallbacks = callback.map(cb => {
+      const wrapper: callbackFn<T> = (value: T) => {
+        cb(value);
+        this.subscribers = this.subscribers.filter(sub => sub !== wrapper);
+      };
+      return wrapper;
+    });
+    this.subscribers.push(...onceCallbacks);
+
+    if (this.immediate && this._value !== null) {
+      for (const cb of onceCallbacks) {
+        void cb(this._value);
+      }
+    }
+
+    // Return an unsubscribe function
+    return () => {
+      this.subscribers = this.subscribers.filter(sub => !onceCallbacks.includes(sub));
+    };
+  }
+
+  /**
+    * Notifies all subscribers with the new value.
+    * @param value - The new value to be passed to subscribers.
+    */
+  private notifySubscribers(value: T) {
+    for (const subscriber of this.subscribers) {
+      subscriber(value);
+    }
+  }
+
+  /**
+    * Clears all subscribers from the signal.
+    */
+  public clearSubscribers() {
+    this.subscribers = [];
+  }
+}

--- a/src/sqlEscaper.test.ts
+++ b/src/sqlEscaper.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import SqlEscaper from './sqlEscaper.js';
+import sqlFlavor from './types/sqlFlavor.js';
+
+
+describe('SQL Escaper', () => {
+
+  it('should escape identifiers correctly', () => {
+    const escaped = SqlEscaper.escape('columnName', '"', null, '""', null);
+    expect(escaped).toBe('"columnName"');
+  })
+
+  it('should escape identifiers with special characters', () => {
+    const escaped = SqlEscaper.escape('column"Name', '"', null, '""', null);
+    expect(escaped).toBe('"column""Name"');
+  });
+
+  it('should escape single table name', () => {
+    const escaped = SqlEscaper.escapeTableName('tableName', sqlFlavor.postgres);
+    expect(escaped).toBe('"tableName"');
+  });
+
+  it('should escape multiple identifiers', () => {
+    const escaped = SqlEscaper.escapeSelectIdentifiers(['column1', 'table.column2', 'column3 AS col3'], sqlFlavor.postgres);
+    expect(escaped).toEqual(['"column1"', '"table"."column2"', '"column3" AS "col3"']);
+  });
+
+  it('should throw error for invalid AS clause', () => {
+    expect(() => {
+      SqlEscaper.escapeSelectIdentifiers(['column1 AS', 'AS col2'], sqlFlavor.postgres);
+    }).toThrow('Invalid identifier with AS clause: column1 AS');
+
+    expect(() => {
+      SqlEscaper.escapeSelectIdentifiers(['AS col2'], sqlFlavor.postgres);
+    }).toThrow('Invalid identifier with AS clause: AS col2');
+  });
+
+  it('should escape table names correctly', () => {
+    const escaped = SqlEscaper.escapeTableName('schema.table', sqlFlavor.postgres);
+    expect(escaped).toBe('"schema"."table"');
+  });
+
+  it('should throw error for invalid table name', () => {
+    expect(() => {
+      SqlEscaper.escapeTableName('schema..table', sqlFlavor.postgres);
+    }).toThrow('Invalid table name: schema..table');
+  });
+
+  it('should not escape schema keywords', () => {
+    const escaped = SqlEscaper.escapeTableName('$schema.table', sqlFlavor.postgres);
+    const escaped2 = SqlEscaper.escapeTableName('$schema1.table', sqlFlavor.postgres);
+    expect(escaped).toBe('$schema."table"');
+    expect(escaped2).toBe('$schema1."table"');
+  });
+
+  it('should handle different SQL flavors', () => {
+    const pgEscaped = SqlEscaper.escapeIdentifier('column', sqlFlavor.postgres);
+    const mysqlEscaped = SqlEscaper.escapeIdentifier('column', sqlFlavor.mysql);
+    const mssqlEscaped = SqlEscaper.escapeIdentifier('column', sqlFlavor.mssql);
+    const sqliteEscaped = SqlEscaper.escapeIdentifier('column', sqlFlavor.sqlite);
+    const oracleEscaped = SqlEscaper.escapeIdentifier('column', sqlFlavor.oracle);
+
+    expect(pgEscaped).toBe('"column"');
+    expect(mysqlEscaped).toBe('`column`');
+    expect(mssqlEscaped).toBe('[column]');
+    expect(sqliteEscaped).toBe('"column"');
+    expect(oracleEscaped).toBe('"column"');
+  });
+
+  it('should escape identifiers with spaces', () => {
+    const escaped = SqlEscaper.escapeIdentifier('column name', sqlFlavor.postgres);
+    expect(escaped).toBe('"column name"');
+  });
+
+  it('should escape identifiers with dots', () => {
+    const escaped = SqlEscaper.escapeIdentifier('table.column', sqlFlavor.postgres);
+    expect(escaped).toBe('"table.column"');
+  });
+
+  it('should append schemas correctly', () => {
+    const escaped1 = SqlEscaper.escapeTableName('$schema.table', sqlFlavor.postgres);
+    const escaped2 = SqlEscaper.escapeTableName('$schema1.table', sqlFlavor.postgres);
+    const escaped = escaped1 + ', ' + escaped2;
+    expect(escaped).toBe('$schema."table", $schema1."table"');
+
+    const appended = SqlEscaper.appendSchemas(escaped, ['someSchema', 'anotherSchema']);
+    expect(appended).toBe('someSchema."table", anotherSchema."table"');
+  });
+
+  it('should throw error if no schemas to append', () => {
+    expect(() => {
+      SqlEscaper.appendSchemas('$schema.table', []);
+    }).toThrow('Schema index 0 out of bounds for provided schemas. Provided schemas: []');
+  });
+
+  it('should throw if flavor is unsupported', () => {
+    expect(() => {
+      SqlEscaper.escapeIdentifier('column', 'unsupportedFlavor' as any);
+    }).toThrowError('Unsupported SQL flavor: unsupportedFlavor');
+  });
+
+  it('should throw if table name or schema is invalid', () => {
+    expect(() => {
+      SqlEscaper.escapeTableName('.table', sqlFlavor.postgres);
+    }).toThrow('Invalid table name with schema: .table');
+  });
+
+})

--- a/src/statementMaker.test.ts
+++ b/src/statementMaker.test.ts
@@ -1,0 +1,600 @@
+import { describe, expect, it } from 'vitest';
+import StatementMaker from './statementMaker.js';
+
+function median(numbers: number[]): number {
+  if (numbers.length === 0) {
+    throw new Error("Array must not be empty");
+  }
+
+  // Sort numbers in ascending order
+  const sorted = [...numbers].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  // If odd length, return middle element
+  if (sorted.length % 2 !== 0) {
+    return sorted[mid]!;
+  }
+
+  // If even length, return average of two middle elements
+  return (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+describe('StatementMaker Basics', () => {
+  it('should pack used values into an array', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3)
+      .build();
+
+    expect(result.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should build a correct SQL statement', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)\n AND (b = $2)\n OR (c = $3)');
+  });
+
+  it('should build a correct SQL statement with nested groups', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and(
+        new StatementMaker()
+          .and('b = ?', 2)
+          .or('c = ?', 3)
+      )
+      .or('d = ?', 4)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)\n AND ((b = $2)\n OR (c = $3))\n OR (d = $4)');
+    expect(result.values)
+      .toEqual([1, 2, 3, 4]);
+  });
+
+  it('should build a correct SQL statement with multiple nested groups', () => {
+    const result = new StatementMaker()
+      .and(
+        new StatementMaker()
+          .and('a = ?', 1)
+          .or('b = ?', 2)
+      )
+      .or(
+        new StatementMaker()
+          .and('c = ?', 3)
+          .and(
+            new StatementMaker()
+              .or('d = ?', 4)
+              .or('e = ?', 5)
+          )
+      )
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE ((a = $1)\n OR (b = $2))\n OR ((c = $3)\n AND ((d = $4)\n OR (e = $5)))');
+    expect(result.values)
+      .toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should build a correct SQL statement without WHERE prefix', () => {
+    const result = new StatementMaker()
+      .disableWhere()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3)
+      .build();
+
+    expect(result.statement)
+      .toBe('(a = $1)\n AND (b = $2)\n OR (c = $3)');
+    expect(result.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should handle no conditions gracefully', () => {
+    const result = new StatementMaker()
+      .build();
+
+    expect(result.statement)
+      .toBe('');
+    expect(result.values)
+      .toEqual([]);
+  });
+
+  it('should handle a single condition without extra parentheses', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)');
+    expect(result.values)
+      .toEqual([1]);
+  });
+
+  it('should handle mixed AND/OR conditions correctly', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .or('b = ?', 2)
+      .and('c = ?', 3)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)\n OR (b = $2)\n AND (c = $3)');
+    expect(result.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('raw queries should just place themselves in the statement', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .raw('', 'b = ?', 2)
+      .or('c = ?', 3)
+      .build();
+
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)\n  (b = $2)\n OR (c = $3)');
+    expect(result.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should throw if less values than placeholders', () => {
+    expect(() => {
+      new StatementMaker()
+        .and('a = ? AND b = ?', 1)
+        .or('c = ?', 2)
+        .build();
+    }).toThrowError('Number of placeholders does not match number of values');
+  });
+
+  it('should throw if more values than placeholders', () => {
+    expect(() => {
+      new StatementMaker()
+        .and('a = ?', [1, 2])
+        .or('c = ?', 3)
+        .build();
+    }).toThrowError('Number of placeholders does not match number of values');
+  });
+
+  it('should throw if more or less values than placeholders in raw', () => {
+    expect(() => {
+      new StatementMaker()
+        .and('a = ?', 1)
+        .raw('', 'b = ? AND c = ?', 2)
+        .or('d = ?', 3)
+        .build();
+    }).toThrowError('Number of placeholders does not match number of values');
+  });
+
+  let firstStart = 0, firstEnd = 0;
+
+  it('should return faster after first build', () => {
+    const maker = new StatementMaker()
+      .enableReparseOnChange()
+      .disableReparseOnChange()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .and(
+        new StatementMaker()
+          .and('c = ?', 3)
+          .or('d = ?', 4)
+          .and(
+            new StatementMaker()
+              .or('f = ?', 5)
+              .or('g = ?', 6)
+          )
+      )
+      .between('e', 5, 10)
+      .notBetween('f', 20, 30)
+      .or('b = ?', 2)
+      .in('h', [1, 2, 3])
+      .notIn('i', [4, 5, 6], 'OR')
+      .like('j', '%test%')
+      .notLike('k', 'test%', 'OR')
+      .ilike('l', '%test%')
+      .notIlike('m', 'test%', 'OR')
+      .isNull('n')
+      .isNotNull('o', 'OR')
+      .exists('SELECT 1 FROM table WHERE p = ?', [1])
+      .notExists('SELECT 1 FROM table WHERE q = ?', [2], 'OR')
+      .disableWhere()
+      .raw('', 'x = ?', 42);
+    
+    let result1, result2;
+    let secondStart = 0, secondEnd = 0;
+
+    const tries = 5;
+    for (let i = 0; i < tries; i++) {
+      runBuild();
+      if (firstEnd - firstStart > secondEnd - secondStart) {
+        break;
+      }
+    }
+
+    function runBuild() {
+      const runs = 5;
+      let firstStarts: number[] = [];
+      let firstEnds: number[] = [];
+      let secondStarts: number[] = [];
+      let secondEnds: number[] = [];
+      for (let i = 0; i < runs; i++) {
+        firstStarts.push(performance.now());
+        result1 = maker.build();
+        firstEnds.push(performance.now());
+        secondStarts.push(performance.now());
+        result2 = maker.build();
+        secondEnds.push(performance.now());
+      }
+
+      firstStart = median(firstStarts);
+      firstEnd = median(firstEnds);
+      secondStart = median(secondStarts);
+      secondEnd = median(secondEnds);
+    }
+
+    console.debug(`First build took ${firstEnd - firstStart} ms`);
+    console.debug(`Second build took ${secondEnd - secondStart} ms`);
+
+    expect(secondEnd - secondStart).toBeLessThan(firstEnd - firstStart);
+    expect(result1).toStrictEqual(result2);
+  });
+
+  it('should return faster compared reparseOnChange = false', () => {
+    const maker = new StatementMaker()
+      .enableReparseOnChange()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .and(
+        new StatementMaker()
+          .and('c = ?', 3)
+          .or('d = ?', 4)
+          .and(
+            new StatementMaker()
+              .or('f = ?', 5)
+              .or('g = ?', 6)
+          )
+      )
+      .between('e', 5, 10)
+      .notBetween('f', 20, 30)
+      .or('b = ?', 2)
+      .in('h', [1, 2, 3])
+      .notIn('i', [4, 5, 6], 'OR')
+      .like('j', '%test%')
+      .notLike('k', 'test%', 'OR')
+      .ilike('l', '%test%')
+      .notIlike('m', 'test%', 'OR')
+      .isNull('n')
+      .isNotNull('o', 'OR')
+      .exists('SELECT 1 FROM table WHERE p = ?', [1])
+      .notExists('SELECT 1 FROM table WHERE q = ?', [2], 'OR')
+      .disableWhere()
+      .raw('', 'x = ?', 42);
+    
+    let result1, result2;
+    let secondStart = 0, secondEnd = 0;
+
+    const tries = 10;
+    for (let i = 0; i < tries; i++) {
+      runBuild();
+      if (firstEnd - firstStart > secondEnd - secondStart) {
+        break;
+      }
+    }
+
+    function runBuild() {
+      const runs = 5;
+      let firstStarts: number[] = [];
+      let firstEnds: number[] = [];
+      let secondStarts: number[] = [];
+      let secondEnds: number[] = [];
+      for (let i = 0; i < runs; i++) {
+        firstStarts.push(performance.now());
+        result1 = maker.build();
+        firstEnds.push(performance.now());
+        secondStarts.push(performance.now());
+        result2 = maker.build();
+        secondEnds.push(performance.now());
+      }
+
+      firstStart = median(firstStarts);
+      firstEnd = median(firstEnds);
+      secondStart = median(secondStarts);
+      secondEnd = median(secondEnds);
+    }
+
+    console.debug(`First build took ${firstEnd - firstStart} ms`);
+    console.debug(`Second build took ${secondEnd - secondStart} ms`);
+
+    expect(secondEnd - secondStart).toBeLessThan(firstEnd - firstStart);
+    expect(result1).toStrictEqual(result2);
+  });
+
+  it('should clone itself correctly', () => {
+    const maker = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    const clone = maker.clone();
+
+    const result1 = maker.build();
+    const result2 = clone.build();
+
+    // Delete internal properties that are not relevant for equality check
+    // These include a lot of anonymous functions created in the process
+    delete (maker as any)?.unsubscribeSignals;
+    delete (clone as any)?.unsubscribeSignals;
+    delete (maker as any)?.index?.subscribers;
+    delete (clone as any)?.index?.subscribers;
+    delete (maker as any)?.statements?.subscribers;
+    delete (clone as any)?.statements?.subscribers;
+    delete (maker as any)?.values?.subscribers;
+    delete (clone as any)?.values?.subscribers;
+
+    expect(clone).not.toBe(maker);
+    expect(clone).toEqual(maker);
+
+    expect(result2).toEqual(result1);
+  });
+
+  it('should return params correctly', () => {
+    const maker = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    expect(maker.params)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should handle enable where after disable where', () => {
+    const result = new StatementMaker()
+      .disableWhere()
+      .and('a = ?', 1)
+      .enableWhere()
+      .and('b = ?', 2)
+      .or('c = ?', 3)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a = $1)\n AND (b = $2)\n OR (c = $3)');
+    expect(result.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should handle addOffset correctly', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    expect(result.params)
+      .toEqual([1, 2, 3]);
+
+    result.addOffset(2);
+
+    expect(result.params)
+      .toEqual([1, 2, 3]);
+
+    const built = result.build();
+    expect(built.statement)
+      .toBe('WHERE (a = $3)\n AND (b = $4)\n OR (c = $5)');
+    expect(built.values)
+      .toEqual([1, 2, 3]);
+  });
+
+  it('should handle addParams correctly', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    expect(result.params)
+      .toEqual([1, 2, 3]);
+
+    result.addParams([4, 5]);
+
+    expect(result.params)
+      .toEqual([4, 5, 1, 2, 3]);
+  });
+
+  it('should handle reseting correctly', () => {
+    const result = new StatementMaker()
+      .and('a = ?', 1)
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    expect(result.params)
+      .toEqual([1, 2, 3]);
+
+    const built1 = result.build();
+    expect(built1.statement)
+      .toBe('WHERE (a = $1)\n AND (b = $2)\n OR (c = $3)');
+    expect(built1.values)
+      .toEqual([1, 2, 3]);
+
+    result.reset();
+
+    expect(result.params)
+      .toEqual([]);
+
+    const built2 = result.build();
+    expect(built2.statement)
+      .toBe('');
+    expect(built2.values)
+      .toEqual([]);
+  });
+
+  it('should handle joining another StatementMaker correctly', () => {
+    const first = new StatementMaker()
+      .and('b = ?', 2)
+      .or('c = ?', 3);
+
+    const second = new StatementMaker()
+      .and('a = ?', 1)
+      .or('d = ?', 4);
+
+    first.joinMultipleStatements([second], 'AND');
+
+    const built = first.build();
+    expect(built.statement)
+      .toBe('WHERE (b = $1)\n OR (c = $2)\n AND ((a = $3)\n OR (d = $4))');
+    expect(built.values)
+      .toEqual([2, 3, 1, 4]);
+  });
+
+});
+
+describe('StatementMaker Composites', () => {
+  it('should handle is null and is not null conditions', () => {
+    const result = new StatementMaker()
+      .isNull('a')
+      .isNotNull('b', 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a IS NULL)\n OR (b IS NOT NULL)');
+    expect(result.values)
+      .toEqual([]);
+  });
+
+  it('should handle in and not in conditions', () => {
+    const result = new StatementMaker()
+      .in('a', [1, 2, 3])
+      .notIn('b', [4, 5, 6], 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a IN ($1, $2, $3))\n OR (b NOT IN ($4, $5, $6))');
+    expect(result.values)
+      .toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('should handle like and not like conditions', () => {
+    const result = new StatementMaker()
+      .like('a', '%test%')
+      .notLike('b', 'test%', 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a LIKE $1)\n OR (b NOT LIKE $2)');
+    expect(result.values)
+      .toEqual(['%test%', 'test%']);
+  });
+
+  it('should handle ilike and not ilike conditions', () => {
+    const result = new StatementMaker()
+      .ilike('a', '%test%')
+      .notIlike('b', 'test%', 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a ILIKE $1)\n OR (b NOT ILIKE $2)');
+    expect(result.values)
+      .toEqual(['%test%', 'test%']);
+  });
+
+  it('should handle exists and not exists conditions', () => {
+    const result = new StatementMaker()
+      .exists('SELECT 1 FROM table WHERE a = ?', [1])
+      .notExists('SELECT 1 FROM table WHERE b = ?', [2], 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (EXISTS (SELECT 1 FROM table WHERE a = $1))\n OR (NOT EXISTS (SELECT 1 FROM table WHERE b = $2))');
+    expect(result.values)
+      .toEqual([1, 2]);
+  });
+
+  it('should handle between and not between conditions', () => {
+    const result = new StatementMaker()
+      .between('a', 1, 10)
+      .notBetween('b', 20, 30)
+      .or('b = ?', 2)
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a BETWEEN $1 AND $2)\n AND (b NOT BETWEEN $3 AND $4)\n OR (b = $5)');
+    expect(result.values)
+      .toEqual([1, 10, 20, 30, 2]);
+  });
+
+
+
+})
+
+describe('StatementMaker Search', () => {
+  
+  it('should handle fulltext search conditions', () => {
+    const result = new StatementMaker()
+      .search()
+      .fulltext('a', 'test', true, 'AND')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a ILIKE $1)');
+    expect(result.values)
+      .toEqual(['%test%']);
+  });
+
+  it('should handle fulltext ts_vector search conditions', () => {
+    const result = new StatementMaker()
+      .search()
+      .fulltextTsVector('a', 'test search', 'english', 'AND')
+      .build();
+
+    expect(result.statement)
+      .toBe("WHERE ((to_tsvector($1, a) @@ to_tsquery($2, $3)))");
+    expect(result.values)
+      .toEqual(['english', 'english', 'test:* & search:*']);
+  });
+
+  it('should handle wordByWord search conditions', () => {
+    const result = new StatementMaker()
+      .search()
+      .wordByWord('a', 'test search', true, 'AND')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a ILIKE $1)\n AND (a ILIKE $2)');
+    expect(result.values)
+      .toEqual(['%test%', '%search%']);
+  });
+
+  it('should handle fuzzy trigram search conditions', () => {
+    const result = new StatementMaker()
+      .search()
+      .fuzzyTrigram('a', 'test', 0.3, 'AND')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE ((a % $1)\n AND (similarity(a, $2) >= $3))');
+    expect(result.values)
+      .toEqual(['test', 'test', 0.3]);
+  });
+
+  it('should handle combined search conditions', () => {
+    const result = new StatementMaker()
+      .search()
+      .fulltext('a', 'test', false, 'OR')
+      .search()
+      .wordByWord('b', 'search term', false, 'OR')
+      .search()
+      .fuzzyTrigram('c', 'fuzzy', 0.4, 'OR')
+      .search()
+      .fulltextTsVector('c', 'fuzzy', 'english', 'OR')
+      .build();
+
+    expect(result.statement)
+      .toBe('WHERE (a LIKE $1)\n OR (b LIKE $2)\n OR (b LIKE $3)\n OR ((c % $4)\n AND (similarity(c, $5) >= $6))\n OR ((to_tsvector($7, c) @@ to_tsquery($8, $9)))');
+    expect(result.values)
+      .toEqual(['%test%', '%search%', '%term%', 'fuzzy', 'fuzzy', 0.4, 'english', 'english', 'fuzzy:*']);
+  });
+});

--- a/src/types/OrderBy.test.ts
+++ b/src/types/OrderBy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isOrderByField } from "./OrderBy.js";
+
+
+describe('Order By is OrderByField', () => {
+  it('should work', () => {
+    const isIt1 = isOrderByField({ field: 'name', direction: 'ASC' });
+    const isIt2 = isOrderByField({ field: 'name', direction: 'desc' });
+    const isIt3 = isOrderByField({ column: 'name', direction: 'ASC' });
+
+    expect(isIt1).toBe(true);
+    expect(isIt2).toBe(true);
+    expect(isIt3).toBe(false);
+  });
+});

--- a/src/types/QueryKind.ts
+++ b/src/types/QueryKind.ts
@@ -1,0 +1,11 @@
+
+
+enum QueryKind {
+  SELECT = "SELECT",
+  INSERT = "INSERT",
+  UPDATE = "UPDATE",
+  DELETE = "DELETE",
+  UNION = "UNION"
+}
+
+export default QueryKind;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   target: ['esnext', 'node21'],
   format: ['cjs', 'esm'],
+  ignoreWatch: ['**/*.test.ts', '**/*.spec.ts'],
   dts: true,
   outDir: 'dist',
   clean: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      reporter: ['json', 'html', 'text'],
+      exclude: [
+        'node_modules',
+        'dist',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        'vitest.config.ts',
+        '**/getOptionalPackages.ts',
+        'src/index.ts',
+      ],
+      include: ['src/**/*.ts']
+    }
+  }
+})


### PR DESCRIPTION
# Unions
Unions are now a separate class that works independently from the SelectQuery, why? Simply because the older solution was much more of a red neck engineering type of thing instead of working reliably, in the past it overrode methods and set arbitrary values on the SelectQuery, now it is it's own thing.

# Testing
Testing was added and covers 90% of the code by v8 coverage metrics. The tool used for testing is Vitest, it is very easy to use so it was a great choice for a simple project like this one.

# RawSelect
Now you can select but without escaping using myQuery.rawSelect or myQuery.addRawSelect.

# Caching of built elements
Queries and parameters already built are now cached and when calling toSQL or getParams from any of the queries it will get the cached values and not build again.

# Major Refactor
Many things were refactored such as repeated elements in many queries such as the whereStatement, invalidation, ctes, builtParams, builtQuery, flavor and lot of other things.

# Validation
I changed how validation works, now validation will return the transformed value as well, so if you have a Zod object or class-transformer object that it will use it's transformation features and return pretty value, if now validation object is specified it will just return the plain-old value directly from the SQL driver.

# Fixes
When adding testing I encountered a lot of hidden bugs (which proves why we need testing ;) ) that were fixed as well.

# Miscellaneous
- Removed message asking for issues.
- Update node version in GitHub workflow so testing works reliably.
- Finished issues #50 and #56.
- Added getter for getting select columns.
- Old union implementation was removed and now returns a Union class in the place of the old SelectQuery used there for some minimal backwards compatibility.